### PR TITLE
[Feat] 회원가입 기능, 이메일 인증 기능 개발 

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,10 +24,23 @@ dependencies {
 	//jpa, mariadb
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
 	//lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
+	//security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.security:spring-security-oauth2-client'
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	// mail
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/synergy/backend/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/synergy/backend/global/security/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.synergy.backend.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+        http.csrf((auth) -> auth.disable());
+        http.httpBasic((auth) -> auth.disable());
+
+        http.authorizeHttpRequests((auth)->
+                auth.anyRequest().permitAll()   // 일시적 모두 허용
+        );
+
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/com/synergy/backend/member/controller/MemberController.java
@@ -1,4 +1,27 @@
 package com.synergy.backend.member.controller;
 
+import com.synergy.backend.member.model.request.MemberSignupReq;
+import com.synergy.backend.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
 public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@RequestBody MemberSignupReq memberSignupReq){
+        String result = memberService.signup(memberSignupReq);
+        return ResponseEntity.ok(result);
+    }
+
+
 }

--- a/backend/src/main/java/com/synergy/backend/member/controller/MemberEmailAuthController.java
+++ b/backend/src/main/java/com/synergy/backend/member/controller/MemberEmailAuthController.java
@@ -1,0 +1,31 @@
+package com.synergy.backend.member.controller;
+
+import com.synergy.backend.member.model.request.MemberEmailAuthReq;
+import com.synergy.backend.member.service.MemberEmailAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/email")
+public class MemberEmailAuthController {
+
+    private final MemberEmailAuthService memberEmailAuthService;
+
+    @PostMapping("/request")
+    public ResponseEntity<String> emailAuthentication(@RequestBody MemberEmailAuthReq req){
+        String uuid = memberEmailAuthService.sendEmail(req);
+        String result = memberEmailAuthService.saveEmailAuthInfo(req,uuid);
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("/verify")
+    public boolean verifyUuid(@RequestBody MemberEmailAuthReq req){
+        boolean result = memberEmailAuthService.verifyUuid(req);
+        return result;
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/member/model/entity/Member.java
+++ b/backend/src/main/java/com/synergy/backend/member/model/entity/Member.java
@@ -2,10 +2,14 @@ package com.synergy.backend.member.model.entity;
 
 import com.synergy.backend.common.model.BaseEntity;
 import jakarta.persistence.*;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "member")
+@NoArgsConstructor
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -15,7 +19,7 @@ public class Member extends BaseEntity {
     private String nickname;
     private String cellPhone;
     private LocalDateTime joinDate;
-    private LocalDateTime birthday;
+    private LocalDate birthday;
     private String gender;
     private Boolean emailAuthentication;
     private String role;
@@ -27,4 +31,23 @@ public class Member extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "default_address_idx")
     private DeliveryAddress defaultAddress;
+
+    @Builder
+    public Member(String email, String password, String nickname, String cellPhone, LocalDateTime joinDate,
+                  LocalDate birthday, String gender,
+                  String profileImageUrl,
+                  DeliveryAddress defaultAddress) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.cellPhone = cellPhone;
+        this.joinDate = joinDate;
+        this.birthday = birthday;
+        this.gender = gender;
+        this.emailAuthentication = false;   // 이메일 인증은 받지 못한 상태
+        this.role = "USER";     // 최초 생성 USER
+//        this.profileImageUrl = profileImageUrl;   // 프로필 이미지는 수정할때만
+//        this.grade = "아기손"; //등급 최저
+//        this.defaultAddress = defaultAddress; //기본 배송지
+    }
 }

--- a/backend/src/main/java/com/synergy/backend/member/model/entity/MemberEmailAuth.java
+++ b/backend/src/main/java/com/synergy/backend/member/model/entity/MemberEmailAuth.java
@@ -1,9 +1,12 @@
 package com.synergy.backend.member.model.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "member_email_auth")
+@NoArgsConstructor
 public class MemberEmailAuth {
 
     @Id
@@ -12,4 +15,14 @@ public class MemberEmailAuth {
 
     private String uuid;
     private String email;
+
+    @Builder
+    public MemberEmailAuth(String uuid, String email) {
+        this.uuid = uuid;
+        this.email = email;
+    }
+
+    public void changeUuid(String uuid) {
+        this.uuid = uuid;
+    }
 }

--- a/backend/src/main/java/com/synergy/backend/member/model/request/MemberEmailAuthReq.java
+++ b/backend/src/main/java/com/synergy/backend/member/model/request/MemberEmailAuthReq.java
@@ -1,0 +1,10 @@
+package com.synergy.backend.member.model.request;
+
+import lombok.Getter;
+
+@Getter
+public class MemberEmailAuthReq {
+
+    private String email;
+    private String uuid;
+}

--- a/backend/src/main/java/com/synergy/backend/member/model/request/MemberSignupReq.java
+++ b/backend/src/main/java/com/synergy/backend/member/model/request/MemberSignupReq.java
@@ -1,4 +1,40 @@
 package com.synergy.backend.member.model.request;
 
+import com.synergy.backend.member.model.entity.Member;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Getter
+@RequiredArgsConstructor
 public class MemberSignupReq {
+
+    private String email;
+    private String password;
+    private String name;
+    private String cellPhone;
+    private LocalDate birthday;
+    private String gender;
+    private String defaultAddress;
+
+    @Builder
+    public static Member toEntity(MemberSignupReq req,BCryptPasswordEncoder bCryptPasswordEncoder) {
+        LocalDateTime localDateTime = LocalDateTime.now();
+        localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+        return Member.builder()
+                .email(req.email)
+                .password(bCryptPasswordEncoder.encode(req.getPassword()))
+                .nickname(req.name)
+                .cellPhone(req.cellPhone)
+                .joinDate(localDateTime)
+                .birthday(req.birthday)
+                .gender(req.gender)
+//                .defaultAddress(req.defaultAddress)
+                .build();
+    }
 }

--- a/backend/src/main/java/com/synergy/backend/member/repository/MemberEmailAuthRepository.java
+++ b/backend/src/main/java/com/synergy/backend/member/repository/MemberEmailAuthRepository.java
@@ -1,0 +1,12 @@
+package com.synergy.backend.member.repository;
+
+import com.synergy.backend.member.model.entity.MemberEmailAuth;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberEmailAuthRepository extends JpaRepository<MemberEmailAuth, Long> {
+
+    Optional<MemberEmailAuth> findByEmail(String email);
+
+    Optional<MemberEmailAuth> findByEmailAndUuid(String email, String uuid);
+}

--- a/backend/src/main/java/com/synergy/backend/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/synergy/backend/member/repository/MemberRepository.java
@@ -1,4 +1,7 @@
 package com.synergy.backend.member.repository;
 
-public class MemberRepository {
+import com.synergy.backend.member.model.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
 }

--- a/backend/src/main/java/com/synergy/backend/member/service/MemberEmailAuthService.java
+++ b/backend/src/main/java/com/synergy/backend/member/service/MemberEmailAuthService.java
@@ -1,0 +1,70 @@
+package com.synergy.backend.member.service;
+
+import com.synergy.backend.member.model.entity.Member;
+import com.synergy.backend.member.model.entity.MemberEmailAuth;
+import com.synergy.backend.member.model.request.MemberEmailAuthReq;
+import com.synergy.backend.member.repository.MemberEmailAuthRepository;
+import com.synergy.backend.member.repository.MemberRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberEmailAuthService {
+
+    private final JavaMailSender emailSender;
+
+    private final MemberEmailAuthRepository memberEmailAuthRepository;
+
+    // 이메일 요청
+    public String sendEmail(MemberEmailAuthReq req) {
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(req.getEmail());
+        message.setSubject("[Come'공방 사이트] 인증 메일 요청");
+
+        String uuid = UUID.randomUUID().toString().substring(0,6).toUpperCase();
+        System.out.println(uuid);
+
+        message.setText("가입을 완료하시려면 회원가입 창으로 돌아간 후 아래 코드를 입력해주세요.\n" + uuid);
+
+        emailSender.send(message);
+
+        return uuid;
+    }
+
+    public String saveEmailAuthInfo(MemberEmailAuthReq req, String uuid) {
+        Optional<MemberEmailAuth> findEmail = memberEmailAuthRepository.findByEmail(req.getEmail());
+        if(findEmail.isPresent()){
+            findEmail.get().changeUuid(uuid);
+            System.out.println("기존에 email이 있어서 uuid 변경");
+            memberEmailAuthRepository.save(findEmail.get());
+            return "저장 성공";
+        }
+        MemberEmailAuth emailAuth = MemberEmailAuth.builder()
+                .email(req.getEmail())
+                .uuid(uuid)
+                .build();
+
+        MemberEmailAuth result = memberEmailAuthRepository.save(emailAuth);
+        if(result == null){
+            return "유효하지 않은 이메일 정보";
+        }
+        return "저장 성공2";
+    }
+
+
+    public boolean verifyUuid(MemberEmailAuthReq req) {
+        Optional<MemberEmailAuth> result = memberEmailAuthRepository.findByEmailAndUuid(req.getEmail(),
+                req.getUuid());
+
+        if(result.isEmpty()){
+            return false;
+        }
+        return true;
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/member/service/MemberService.java
+++ b/backend/src/main/java/com/synergy/backend/member/service/MemberService.java
@@ -1,4 +1,35 @@
 package com.synergy.backend.member.service;
 
+import com.synergy.backend.member.model.entity.Member;
+import com.synergy.backend.member.model.request.MemberSignupReq;
+import com.synergy.backend.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    public String signup(MemberSignupReq memberSignupReq) {
+        LocalDateTime localDateTime = LocalDateTime.now();
+        localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+        Member member = MemberSignupReq.toEntity(memberSignupReq,bCryptPasswordEncoder);
+        Member result = memberRepository.save(member);
+
+        try{
+            if(result == null){
+                throw new Exception("회원 저장이 잘못되었습니다.");
+            }
+        }catch (Exception e){
+            return e.getMessage();
+        }
+
+        return "회원 저장 성공";
+    }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 server:
   port: ${PORT}
 spring:
+  jwt:
+    secret: ${JWT_SECRET_KEY}
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}
@@ -15,3 +17,25 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+  mail:
+    host: smtp.gmail.com  #SMTP sever host  : fix address
+    port: 587 #SMTP server port : fix value
+    username: ${SMTP_USERNAME}
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true  # start TLS
+            required: true
+          auth: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace  #show '?' in sql in console
+


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->
#2 #3

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->

- 회원가입 기능개발
- BcryptPassword 을 사용 및 , 암호화하여 db 안에 password저장
- toEntity() 메서드를 DTO 안에 구현함으로서 Entity-Dto 간의 결합도 낮춤

<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->

사전에 SYNergy 코드 컨벤션에 정했던 DTO-Entity 변환 코드를 작성하여, Service 측의 코드 가독성을 높였습니다.
![image](https://github.com/user-attachments/assets/ce6ce469-4326-4bea-baa0-393f5ba93300)

해당 변환 메서드를 Entity 측에 작성할 것인가? DTO 측에 작성할 것인가? 고민이 있었으나, 각각의 장단점을 분석 및 결합도를 낮추는 방법을 도입하여 DTO 측에 작성하였습니다. 각각의 장단점을 팀원 모두 명확히 이해하고 사용하는 것이 권장됩니다.
![image](https://github.com/user-attachments/assets/b885c684-c407-446a-9115-a313c6aaa544)



<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->

- toDto() , toEntity() 와 같은 변환 메서드를 어디다가 쓸 것인가에 대한 고민과 장단점 여부를 다같이 공부해보면 좋을 듯 해요!
- 기본배송지와 등급과 같이 객체가 필요로 하는 것은 일단, null처리 하였습니다! 추후 반영시키겠습니다.

- 이메일 인증 여부를 의미하는 컬럼에 대한 고민
이메일 인증 요청 api를 구현하면서 생긴 의구심입니다. 
-> 기존 테이블은 이메일 인증을 무사히 마친 회원만 정상 로그인이 가능하도록 시나리오를 구상해서, 회원 테이블에 email-authentication 컬럼이 존재하였습니다. 

다만, 회원가입의 시나리오상, 이메일 인증에 대한 여부를 마쳐야 회원가입에 대한 요청을 보내서 DB에 저장하도록 프론트엔드 측에서 구현이 가능할 것으로 보이는데, 회원 테이블 안에서 인증 여부 컬럼을 빼도 상관없을 지 의견을 나누고 싶습니다.
![image](https://github.com/user-attachments/assets/a9d13b5b-a6b5-48b2-a452-de54c6bce0a3)
![image](https://github.com/user-attachments/assets/ff4910b7-c1e1-42d3-8ffb-2bc40e26aea9)

<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

[변환메서드를 어디에?](https://www.inflearn.com/community/questions/1238628/dto%EC%97%90%EC%84%9C-toentity-vs-entity-%EC%95%88%EC%97%90-%EC%A0%95%EC%A0%81-%ED%8C%A9%ED%86%A0%EB%A6%AC-%EB%A9%94%EC%84%9C%EB%93%9C)



<br><br>
