### PR TITLE
[Feat] 배송지 관리 페이지 컴포넌트 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.7.7",
         "core-js": "^3.8.3",
         "pinia": "^2.2.2",
         "pinia-plugin-persistedstate": "^4.0.0",
@@ -3670,6 +3671,12 @@
         "lodash": "^4.17.14"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -3714,6 +3721,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-loader": {
@@ -4426,6 +4443,18 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "8.3.0",
@@ -5219,6 +5248,15 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -6447,7 +6485,6 @@
       "version": "1.15.8",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.8.tgz",
       "integrity": "sha512-xgrmBhBToVKay1q2Tao5LI26B83UhrB/vM1avwVSDzt8rx3rO6AizBAaF46EgksTVr+rFTQaqZZ9MVBfUe4nig==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -6461,6 +6498,20 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -8031,7 +8082,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8040,7 +8090,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -9831,6 +9880,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "axios": "^1.7.7",
     "core-js": "^3.8.3",
     "pinia": "^2.2.2",
     "pinia-plugin-persistedstate": "^4.0.0",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,16 +1,21 @@
 <!DOCTYPE html>
 <html lang="">
   <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <link rel="icon" href="<%= BASE_URL %>favicon.ico" />
     <title><%= htmlWebpackPlugin.options.title %></title>
-    <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="/styles.css" />
+    <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
   </head>
   <body>
     <noscript>
-      <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+      <strong
+        >We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work
+        properly without JavaScript enabled. Please enable it to
+        continue.</strong
+      >
     </noscript>
     <div id="app"></div>
     <!-- built files will be auto injected -->

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,15 +1,13 @@
 <template>
-  <!-- <img alt="Vue logo" src="./assets/logo.png"> -->
-  <HelloWorld msg="Welcome to Your Vue.js App"/>
+<router-view></router-view>
 </template>
 
 <script>
-import HelloWorld from './components/HelloWorld.vue'
 
 export default {
   name: 'App',
   components: {
-    HelloWorld
+
   }
 }
 </script>

--- a/frontend/src/components/member/AddAddressComponent.vue
+++ b/frontend/src/components/member/AddAddressComponent.vue
@@ -776,7 +776,7 @@
                                   data-v-6d6ea1ac=""
                                   class="BaseTextField BaseTextField--large"
                                   ><!----><input
-                                    v-model="address.deliveryName"
+                                    v-model="address.addressName"
                                     data-v-6d6ea1ac=""
                                     id="addressName"
                                     name="addressName"

--- a/frontend/src/components/member/AddAddressComponent.vue
+++ b/frontend/src/components/member/AddAddressComponent.vue
@@ -1,0 +1,1236 @@
+<template>
+  <div
+    data-v-60bedabc=""
+    class="BaseDialog flex justify-center items-center fixed top-0 left-0"
+    style="--dialog-footer: 0"
+  >
+    <div data-v-60bedabc="" class="BaseDialog__scrim"></div>
+    <div
+      data-v-60bedabc=""
+      class="BaseDialog__wrapper--medium--basic BaseDialog__container"
+      tabindex="0"
+    >
+      <div data-v-899a28fb="" data-v-60bedabc="">
+        <div
+          data-v-899a28fb=""
+          class="BaseCommonHeader--divider w-full flex justify-center items-center"
+        >
+          <span
+            @click="cancel"
+            data-v-899a28fb=""
+            class="BaseCommonHeader__slot flex shrink-0 items-center justify-center grow-0 mx-[8px]"
+            ><span
+              data-v-60bedabc=""
+              class="BaseDialog__close flex justify-center items-center"
+              ><button
+                data-v-524f63ea=""
+                data-v-778c1d9b=""
+                data-v-60bedabc=""
+                type="button"
+                class="CoreButton BaseButtonIcon"
+                style="
+                  background-color: transparent;
+                  color: rgb(51, 51, 51);
+                  height: 40px;
+                  width: 40px;
+                  flex-direction: column;
+                "
+              >
+                <!---->
+                <svg
+                  data-v-6d2bd019=""
+                  data-v-524f63ea=""
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="BaseIcon CoreButton__icon"
+                  style="
+                    width: 24px;
+                    height: 24px;
+                    opacity: 1;
+                    fill: currentcolor;
+                    --BaseIcon-color: #333333;
+                    margin-bottom: 0px;
+                  "
+                >
+                  <g clip-path="url(#clip0_124_2945)">
+                    <path
+                      fill-rule="evenodd"
+                      clip-rule="evenodd"
+                      d="M18.4697 4.46973L19.5303 5.53039L13.0597 11.9997L19.5303 18.4697L18.4697 19.5304L11.9997 13.0597L5.53033 19.5304L4.46967 18.4697L10.9397 11.9997L4.46967 5.53039L5.53033 4.46973L11.9997 10.9397L18.4697 4.46973Z"
+                    ></path>
+                  </g>
+                  <defs>
+                    <clippath id="clip0_124_2945">
+                      <rect width="24" height="24"></rect>
+                    </clippath>
+                  </defs>
+                </svg>
+                <div data-v-524f63ea="" class="inline-flex items-center">
+                  <!---->
+                </div>
+              </button></span
+            ></span
+          >
+
+          <!-- 배송지 변경  -->
+          <span data-v-899a28fb="" class="flex items-center grow"
+            ><span
+              data-v-899a28fb=""
+              class="subtitle3-bold-small grow gray-333--text text-center break-all line-clamp-1"
+              >배송지 변경</span
+            ></span
+          ><span
+            data-v-899a28fb=""
+            class="BaseCommonHeader__slot flex shrink-0 items-center justify-center grow-0 mx-[8px]"
+          ></span>
+        </div>
+      </div>
+      <div data-v-60bedabc="" class="BaseDialog__contents">
+        <!---->
+        <div data-v-60bedabc="" class="BaseDialog__contentsInner">
+          <div class="h-[496px]">
+            <div class="p-[16px]">
+              <button
+                data-v-524f63ea=""
+                data-v-7940d6dd=""
+                type="outline"
+                class="CoreButton CoreButton--block BaseButtonRectangle subtitle3-bold-small BaseButtonRectangle__outline"
+                style="
+                  background-color: rgb(255, 255, 255);
+                  color: rgb(239, 112, 20);
+                  height: 44px;
+                  flex-direction: row;
+                  --core-button-padding-x: 16;
+                  --button-rectangle-border-color: #ef7014;
+                "
+              >
+                <!----><svg
+                  data-v-6d2bd019=""
+                  data-v-524f63ea=""
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="BaseIcon CoreButton__icon"
+                  style="
+                    width: 20px;
+                    height: 20px;
+                    opacity: 1;
+                    fill: currentcolor;
+                    --BaseIcon-color: #333333;
+                    margin-right: 2px;
+                  "
+                >
+                  <g clip-path="url(#clip0_124_2960)">
+                    <path
+                      fill-rule="evenodd"
+                      clip-rule="evenodd"
+                      d="M12.75 5V11.25H19V12.75H12.75V19H11.25V12.75H5V11.25H11.25V5H12.75Z"
+                    ></path>
+                  </g>
+                  <defs>
+                    <clippath id="clip0_124_2960">
+                      <rect width="24" height="24"></rect>
+                    </clippath>
+                  </defs>
+                </svg>
+                <div data-v-524f63ea="" class="inline-flex items-center">
+                  <span data-v-524f63ea="" class="CoreButton__text"
+                    >배송지 추가하기</span
+                  >
+                </div>
+              </button>
+              <div
+                data-v-60bedabc=""
+                class="BaseDialog flex justify-center items-center fixed top-0 left-0"
+                style="--ids-dialog-scrim-opacity: 0; --dialog-footer: 56"
+              >
+                <div data-v-60bedabc="" class="BaseDialog__scrim"></div>
+                <div
+                  data-v-60bedabc=""
+                  class="BaseDialog__wrapper--medium--basic BaseDialog__container"
+                  tabindex="0"
+                >
+                  <div data-v-899a28fb="" data-v-60bedabc="">
+                    <div
+                      data-v-899a28fb=""
+                      class="BaseCommonHeader--divider w-full flex justify-center items-center"
+                    >
+                      <span
+                        data-v-899a28fb=""
+                        class="BaseCommonHeader__slot flex shrink-0 items-center justify-center grow-0 mx-[8px]"
+                        ><span
+                          data-v-60bedabc=""
+                          class="BaseDialog__close flex justify-center items-center"
+                          ><button
+                            data-v-524f63ea=""
+                            data-v-778c1d9b=""
+                            data-v-60bedabc=""
+                            type="button"
+                            @click="cancel"
+                            class="CoreButton BaseButtonIcon"
+                            style="
+                              background-color: transparent;
+                              color: rgb(51, 51, 51);
+                              height: 40px;
+                              width: 40px;
+                              flex-direction: column;
+                            "
+                          >
+                            <!----><svg
+                              data-v-6d2bd019=""
+                              data-v-524f63ea=""
+                              width="24"
+                              height="24"
+                              viewBox="0 0 24 24"
+                              xmlns="http://www.w3.org/2000/svg"
+                              class="BaseIcon CoreButton__icon"
+                              style="
+                                width: 24px;
+                                height: 24px;
+                                opacity: 1;
+                                fill: currentcolor;
+                                --BaseIcon-color: #333333;
+                                margin-bottom: 0px;
+                              "
+                            >
+                              <g clip-path="url(#clip0_124_2945)">
+                                <path
+                                  fill-rule="evenodd"
+                                  clip-rule="evenodd"
+                                  d="M18.4697 4.46973L19.5303 5.53039L13.0597 11.9997L19.5303 18.4697L18.4697 19.5304L11.9997 13.0597L5.53033 19.5304L4.46967 18.4697L10.9397 11.9997L4.46967 5.53039L5.53033 4.46973L11.9997 10.9397L18.4697 4.46973Z"
+                                ></path>
+                              </g>
+                              <defs>
+                                <clippath id="clip0_124_2945">
+                                  <rect width="24" height="24"></rect>
+                                </clippath>
+                              </defs>
+                            </svg>
+                            <div
+                              data-v-524f63ea=""
+                              class="inline-flex items-center"
+                            >
+                              <!---->
+                            </div>
+                          </button></span
+                        ></span
+                      >
+
+                      <span data-v-899a28fb="" class="flex items-center grow"
+                        ><span
+                          data-v-899a28fb=""
+                          class="subtitle3-bold-small grow gray-333--text text-center break-all line-clamp-1"
+                          >배송지 추가</span
+                        ></span
+                      ><span
+                        data-v-899a28fb=""
+                        class="BaseCommonHeader__slot flex shrink-0 items-center justify-center grow-0 mx-[8px]"
+                      ></span>
+                    </div>
+                  </div>
+                  <div data-v-60bedabc="" class="BaseDialog__contents">
+                    <!---->
+                    <div data-v-60bedabc="" class="BaseDialog__contentsInner">
+                      <div class="h-[440px] pt-[20px] pb-[40px] px-[20px]">
+                        <div
+                          data-v-4a727d65=""
+                          class="DeliveryForm w-full flex flex-col gap-[12px]"
+                        >
+                          <!-- 수령인-->
+                          <div data-v-4a727d65="" class="DeliveryForm__row">
+                            <div
+                              data-v-e2593c18=""
+                              data-v-4a727d65=""
+                              class="BaseLabelText DeliveryForm__label"
+                            >
+                              <span
+                                data-v-e2593c18=""
+                                class="BaseLabelText__text"
+                                >수령인</span
+                              ><span
+                                data-v-e2593c18=""
+                                class="BaseLabelText__mark"
+                                >*</span
+                              >
+                            </div>
+                            <div
+                              data-v-4a727d65=""
+                              class="DeliveryForm__textField"
+                            >
+                              <div
+                                data-v-6d6ea1ac=""
+                                class="BaseTextField__container"
+                                showerrormessage="true"
+                              >
+                                <div
+                                  data-v-e2593c18=""
+                                  data-v-6d6ea1ac=""
+                                  class="BaseLabelText"
+                                  style="display: none"
+                                >
+                                  <span
+                                    data-v-e2593c18=""
+                                    class="BaseLabelText__text"
+                                  ></span
+                                  ><span
+                                    data-v-e2593c18=""
+                                    class="BaseLabelText__mark"
+                                    >*</span
+                                  >
+                                </div>
+                                <input
+                                  data-v-6d6ea1ac=""
+                                  type="text"
+                                  class="BaseTextField__hiddenInput"
+                                  tabindex="-1"
+                                /><label
+                                  data-v-6d6ea1ac=""
+                                  class="BaseTextField BaseTextField--large"
+                                  ><!---->
+                                  <input
+                                    v-model="address.recipient"
+                                    data-v-6d6ea1ac=""
+                                    id="receiverName"
+                                    name="receiverName"
+                                    type="text"
+                                    class="BaseTextField__input BaseTextField__input--left"
+                                    placeholder="이름을 입력해주세요."
+                                    maxlength="20"
+                                    autocomplete="off"
+                                  /><!----><button
+                                    data-v-524f63ea=""
+                                    data-v-778c1d9b=""
+                                    data-v-6d6ea1ac=""
+                                    type="button"
+                                    class="CoreButton BaseButtonIcon BaseTextField__clearIcon"
+                                    style="
+                                      background-color: transparent;
+                                      color: rgb(172, 172, 172);
+                                      height: 24px;
+                                      flex-direction: column;
+                                      display: none;
+                                    "
+                                  >
+                                    <!----><svg
+                                      data-v-6d2bd019=""
+                                      data-v-524f63ea=""
+                                      width="24"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      class="BaseIcon CoreButton__icon"
+                                      style="
+                                        width: 24px;
+                                        height: 24px;
+                                        opacity: 1;
+                                        fill: currentcolor;
+                                        --BaseIcon-color: #333333;
+                                        margin-bottom: 0px;
+                                      "
+                                    >
+                                      <g clip-path="url(#clip0_124_2957)">
+                                        <path
+                                          fill-rule="evenodd"
+                                          clip-rule="evenodd"
+                                          d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM15.4697 7.46967L11.9997 10.9397L8.53033 7.46967L7.46967 8.53033L10.9397 11.9997L7.46967 15.4697L8.53033 16.5303L11.9997 13.0597L15.4697 16.5303L16.5303 15.4697L13.0597 11.9997L16.5303 8.53033L15.4697 7.46967Z"
+                                        ></path>
+                                      </g>
+                                      <defs>
+                                        <clippath id="clip0_124_2957">
+                                          <rect width="24" height="24"></rect>
+                                        </clippath>
+                                      </defs>
+                                    </svg>
+                                    <div
+                                      data-v-524f63ea=""
+                                      class="inline-flex items-center"
+                                    >
+                                      <!---->
+                                    </div></button
+                                  ><!----></label
+                                ><!---->
+                              </div>
+                            </div>
+                          </div>
+
+                          <!-- 주소 -->
+                          <div
+                            id="postcode"
+                            @click="openPostcode"
+                            data-v-4a727d65=""
+                            class="DeliveryForm__row"
+                          >
+                            <div
+                              data-v-e2593c18=""
+                              data-v-4a727d65=""
+                              class="BaseLabelText DeliveryForm__label"
+                            >
+                              <span
+                                data-v-e2593c18=""
+                                class="BaseLabelText__text"
+                                >주소</span
+                              ><span
+                                data-v-e2593c18=""
+                                class="BaseLabelText__mark"
+                                >*</span
+                              >
+                            </div>
+                            <div
+                              data-v-4a727d65=""
+                              class="DeliveryForm__textField"
+                            >
+                              <div
+                                data-v-6d6ea1ac=""
+                                class="BaseTextField__container"
+                                showerrormessage="true"
+                              >
+                                <div
+                                  data-v-e2593c18=""
+                                  data-v-6d6ea1ac=""
+                                  class="BaseLabelText"
+                                  style="display: none"
+                                >
+                                  <span
+                                    data-v-e2593c18=""
+                                    class="BaseLabelText__text"
+                                  ></span
+                                  ><span
+                                    data-v-e2593c18=""
+                                    class="BaseLabelText__mark"
+                                    >*</span
+                                  >
+                                </div>
+                                <input
+                                  data-v-6d6ea1ac=""
+                                  type="text"
+                                  class="BaseTextField__hiddenInput"
+                                  tabindex="-1"
+                                /><label
+                                  data-v-6d6ea1ac=""
+                                  class="BaseTextField BaseTextField--large"
+                                >
+                                  <div
+                                    data-v-6d6ea1ac=""
+                                    class="inline-flex mr-[8px]"
+                                  >
+                                    <svg
+                                      data-v-6d2bd019=""
+                                      data-v-6d6ea1ac=""
+                                      width="24"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      class="BaseIcon m-[2px]"
+                                      style="
+                                        width: 24px;
+                                        height: 24px;
+                                        opacity: 1;
+                                        fill: currentcolor;
+                                        --BaseIcon-color: #666666;
+                                      "
+                                    >
+                                      <g clip-path="url(#clip0_124_2969)">
+                                        <path
+                                          fill-rule="evenodd"
+                                          clip-rule="evenodd"
+                                          d="M10.86 2.60999C15.4163 2.60999 19.11 6.30364 19.11 10.86C19.11 12.8679 18.3927 14.7082 17.2004 16.1388L21.3903 20.3297L20.3297 21.3903L16.1388 17.2004C14.7082 18.3927 12.8679 19.11 10.86 19.11C6.30364 19.11 2.60999 15.4163 2.60999 10.86C2.60999 6.30364 6.30364 2.60999 10.86 2.60999ZM10.86 4.10999C7.13206 4.10999 4.10999 7.13206 4.10999 10.86C4.10999 14.5879 7.13206 17.61 10.86 17.61C14.5879 17.61 17.61 14.5879 17.61 10.86C17.61 7.13206 14.5879 4.10999 10.86 4.10999Z"
+                                        ></path>
+                                      </g>
+                                      <defs>
+                                        <clippath id="clip0_124_2969">
+                                          <rect width="24" height="24"></rect>
+                                        </clippath>
+                                      </defs>
+                                    </svg>
+                                  </div>
+                                  <input
+                                    data-v-6d6ea1ac=""
+                                    id="addressSearch"
+                                    v-model="address.address"
+                                    name="addressSearch"
+                                    type="text"
+                                    class="BaseTextField__input BaseTextField__input--left"
+                                    placeholder="주소 검색"
+                                    readonly=""
+                                    autocomplete="off"
+                                  /><!----><button
+                                    data-v-524f63ea=""
+                                    data-v-778c1d9b=""
+                                    data-v-6d6ea1ac=""
+                                    type="button"
+                                    class="CoreButton BaseButtonIcon BaseTextField__clearIcon"
+                                    style="
+                                      background-color: transparent;
+                                      color: rgb(172, 172, 172);
+                                      height: 24px;
+                                      flex-direction: column;
+                                      display: none;
+                                    "
+                                  >
+                                    <!----><svg
+                                      data-v-6d2bd019=""
+                                      data-v-524f63ea=""
+                                      width="24"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      class="BaseIcon CoreButton__icon"
+                                      style="
+                                        width: 24px;
+                                        height: 24px;
+                                        opacity: 1;
+                                        fill: currentcolor;
+                                        --BaseIcon-color: #333333;
+                                        margin-bottom: 0px;
+                                      "
+                                    >
+                                      <g clip-path="url(#clip0_124_2957)">
+                                        <path
+                                          fill-rule="evenodd"
+                                          clip-rule="evenodd"
+                                          d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM15.4697 7.46967L11.9997 10.9397L8.53033 7.46967L7.46967 8.53033L10.9397 11.9997L7.46967 15.4697L8.53033 16.5303L11.9997 13.0597L15.4697 16.5303L16.5303 15.4697L13.0597 11.9997L16.5303 8.53033L15.4697 7.46967Z"
+                                        ></path>
+                                      </g>
+                                      <defs>
+                                        <clippath id="clip0_124_2957">
+                                          <rect width="24" height="24"></rect>
+                                        </clippath>
+                                      </defs>
+                                    </svg>
+                                    <div
+                                      data-v-524f63ea=""
+                                      class="inline-flex items-center"
+                                    >
+                                      <!---->
+                                    </div></button
+                                  ><!----> </label
+                                ><!---->
+                              </div>
+                            </div>
+                          </div>
+                          <!-- 상세주소-->
+                          <div data-v-4a727d65="" class="DeliveryForm__row">
+                            <div
+                              data-v-e2593c18=""
+                              data-v-4a727d65=""
+                              class="BaseLabelText DeliveryForm__label"
+                            >
+                              <span
+                                data-v-e2593c18=""
+                                class="BaseLabelText__text"
+                                >상세주소</span
+                              ><!---->
+                            </div>
+                            <div
+                              data-v-4a727d65=""
+                              class="DeliveryForm__textField"
+                            >
+                              <div
+                                data-v-6d6ea1ac=""
+                                class="BaseTextField__container"
+                                showerrormessage="true"
+                              >
+                                <div
+                                  data-v-e2593c18=""
+                                  data-v-6d6ea1ac=""
+                                  class="BaseLabelText"
+                                  style="display: none"
+                                >
+                                  <span
+                                    data-v-e2593c18=""
+                                    class="BaseLabelText__text"
+                                  ></span
+                                  ><!---->
+                                </div>
+                                <input
+                                  data-v-6d6ea1ac=""
+                                  type="text"
+                                  class="BaseTextField__hiddenInput"
+                                  tabindex="-1"
+                                /><label
+                                  data-v-6d6ea1ac=""
+                                  class="BaseTextField BaseTextField--large"
+                                  ><!----><input
+                                    v-model="address.detailAddress"
+                                    data-v-6d6ea1ac=""
+                                    id="addressDetail"
+                                    name="addressDetail"
+                                    type="text"
+                                    class="BaseTextField__input BaseTextField__input--left"
+                                    placeholder="나머지 주소를 입력해주세요."
+                                    maxlength="100"
+                                    autocomplete="off"
+                                  /><!----><button
+                                    data-v-524f63ea=""
+                                    data-v-778c1d9b=""
+                                    data-v-6d6ea1ac=""
+                                    type="button"
+                                    class="CoreButton BaseButtonIcon BaseTextField__clearIcon"
+                                    style="
+                                      background-color: transparent;
+                                      color: rgb(172, 172, 172);
+                                      height: 24px;
+                                      flex-direction: column;
+                                      display: none;
+                                    "
+                                  >
+                                    <!----><svg
+                                      data-v-6d2bd019=""
+                                      data-v-524f63ea=""
+                                      width="24"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      class="BaseIcon CoreButton__icon"
+                                      style="
+                                        width: 24px;
+                                        height: 24px;
+                                        opacity: 1;
+                                        fill: currentcolor;
+                                        --BaseIcon-color: #333333;
+                                        margin-bottom: 0px;
+                                      "
+                                    >
+                                      <g clip-path="url(#clip0_124_2957)">
+                                        <path
+                                          fill-rule="evenodd"
+                                          clip-rule="evenodd"
+                                          d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM15.4697 7.46967L11.9997 10.9397L8.53033 7.46967L7.46967 8.53033L10.9397 11.9997L7.46967 15.4697L8.53033 16.5303L11.9997 13.0597L15.4697 16.5303L16.5303 15.4697L13.0597 11.9997L16.5303 8.53033L15.4697 7.46967Z"
+                                        ></path>
+                                      </g>
+                                      <defs>
+                                        <clippath id="clip0_124_2957">
+                                          <rect width="24" height="24"></rect>
+                                        </clippath>
+                                      </defs>
+                                    </svg>
+                                    <div
+                                      data-v-524f63ea=""
+                                      class="inline-flex items-center"
+                                    >
+                                      <!---->
+                                    </div></button
+                                  ><!----></label
+                                ><!---->
+                              </div>
+                            </div>
+                          </div>
+                          <!-- 휴대폰 -->
+                          <div data-v-4a727d65="" class="DeliveryForm__row">
+                            <div
+                              data-v-e2593c18=""
+                              data-v-4a727d65=""
+                              class="BaseLabelText DeliveryForm__label"
+                            >
+                              <span
+                                data-v-e2593c18=""
+                                class="BaseLabelText__text"
+                                >휴대폰</span
+                              ><span
+                                data-v-e2593c18=""
+                                class="BaseLabelText__mark"
+                                >*</span
+                              >
+                            </div>
+                            <div
+                              data-v-4a727d65=""
+                              class="DeliveryForm__textField"
+                            >
+                              <div
+                                data-v-6d6ea1ac=""
+                                class="BaseTextField__container"
+                                showerrormessage="true"
+                              >
+                                <div
+                                  data-v-e2593c18=""
+                                  data-v-6d6ea1ac=""
+                                  class="BaseLabelText"
+                                  style="display: none"
+                                >
+                                  <span
+                                    data-v-e2593c18=""
+                                    class="BaseLabelText__text"
+                                  ></span
+                                  ><span
+                                    data-v-e2593c18=""
+                                    class="BaseLabelText__mark"
+                                    >*</span
+                                  >
+                                </div>
+                                <input
+                                  data-v-6d6ea1ac=""
+                                  type="text"
+                                  class="BaseTextField__hiddenInput"
+                                  tabindex="-1"
+                                /><label
+                                  data-v-6d6ea1ac=""
+                                  class="BaseTextField BaseTextField--large"
+                                  ><!----><input
+                                    v-model="address.cellPhone"
+                                    data-v-6d6ea1ac=""
+                                    id="receiverPhone"
+                                    name="receiverPhone"
+                                    type="text"
+                                    class="BaseTextField__input BaseTextField__input--left"
+                                    placeholder="숫자만 입력해주세요."
+                                    maxlength="13"
+                                    autocomplete="off"
+                                  /><!----><button
+                                    data-v-524f63ea=""
+                                    data-v-778c1d9b=""
+                                    data-v-6d6ea1ac=""
+                                    type="button"
+                                    class="CoreButton BaseButtonIcon BaseTextField__clearIcon"
+                                    style="
+                                      background-color: transparent;
+                                      color: rgb(172, 172, 172);
+                                      height: 24px;
+                                      flex-direction: column;
+                                      display: none;
+                                    "
+                                  >
+                                    <!----><svg
+                                      data-v-6d2bd019=""
+                                      data-v-524f63ea=""
+                                      width="24"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      class="BaseIcon CoreButton__icon"
+                                      style="
+                                        width: 24px;
+                                        height: 24px;
+                                        opacity: 1;
+                                        fill: currentcolor;
+                                        --BaseIcon-color: #333333;
+                                        margin-bottom: 0px;
+                                      "
+                                    >
+                                      <g clip-path="url(#clip0_124_2957)">
+                                        <path
+                                          fill-rule="evenodd"
+                                          clip-rule="evenodd"
+                                          d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM15.4697 7.46967L11.9997 10.9397L8.53033 7.46967L7.46967 8.53033L10.9397 11.9997L7.46967 15.4697L8.53033 16.5303L11.9997 13.0597L15.4697 16.5303L16.5303 15.4697L13.0597 11.9997L16.5303 8.53033L15.4697 7.46967Z"
+                                        ></path>
+                                      </g>
+                                      <defs>
+                                        <clippath id="clip0_124_2957">
+                                          <rect width="24" height="24"></rect>
+                                        </clippath>
+                                      </defs>
+                                    </svg>
+                                    <div
+                                      data-v-524f63ea=""
+                                      class="inline-flex items-center"
+                                    >
+                                      <!---->
+                                    </div></button
+                                  ><!----></label
+                                ><!---->
+                              </div>
+                            </div>
+                          </div>
+                          <!-- 배송지명 -->
+                          <div data-v-4a727d65="" class="DeliveryForm__row">
+                            <div
+                              data-v-e2593c18=""
+                              data-v-4a727d65=""
+                              class="BaseLabelText DeliveryForm__label"
+                            >
+                              <span
+                                data-v-e2593c18=""
+                                class="BaseLabelText__text"
+                                >배송지명</span
+                              ><!---->
+                            </div>
+                            <div
+                              data-v-4a727d65=""
+                              class="DeliveryForm__textField"
+                            >
+                              <div
+                                data-v-6d6ea1ac=""
+                                class="BaseTextField__container"
+                                showerrormessage="true"
+                              >
+                                <div
+                                  data-v-e2593c18=""
+                                  data-v-6d6ea1ac=""
+                                  class="BaseLabelText"
+                                  style="display: none"
+                                >
+                                  <span
+                                    data-v-e2593c18=""
+                                    class="BaseLabelText__text"
+                                  ></span
+                                  ><!---->
+                                </div>
+                                <input
+                                  data-v-6d6ea1ac=""
+                                  type="text"
+                                  class="BaseTextField__hiddenInput"
+                                  tabindex="-1"
+                                /><label
+                                  data-v-6d6ea1ac=""
+                                  class="BaseTextField BaseTextField--large"
+                                  ><!----><input
+                                    v-model="address.deliveryName"
+                                    data-v-6d6ea1ac=""
+                                    id="addressName"
+                                    name="addressName"
+                                    type="text"
+                                    class="BaseTextField__input BaseTextField__input--left"
+                                    placeholder="직접 입력하거나 선택해주세요."
+                                    maxlength="20"
+                                    autocomplete="off"
+                                  /><!----><button
+                                    data-v-524f63ea=""
+                                    data-v-778c1d9b=""
+                                    data-v-6d6ea1ac=""
+                                    type="button"
+                                    class="CoreButton BaseButtonIcon BaseTextField__clearIcon"
+                                    style="
+                                      background-color: transparent;
+                                      color: rgb(172, 172, 172);
+                                      height: 24px;
+                                      flex-direction: column;
+                                      display: none;
+                                    "
+                                  >
+                                    <!----><svg
+                                      data-v-6d2bd019=""
+                                      data-v-524f63ea=""
+                                      width="24"
+                                      height="24"
+                                      viewBox="0 0 24 24"
+                                      xmlns="http://www.w3.org/2000/svg"
+                                      class="BaseIcon CoreButton__icon"
+                                      style="
+                                        width: 24px;
+                                        height: 24px;
+                                        opacity: 1;
+                                        fill: currentcolor;
+                                        --BaseIcon-color: #333333;
+                                        margin-bottom: 0px;
+                                      "
+                                    >
+                                      <g clip-path="url(#clip0_124_2957)">
+                                        <path
+                                          fill-rule="evenodd"
+                                          clip-rule="evenodd"
+                                          d="M12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2ZM15.4697 7.46967L11.9997 10.9397L8.53033 7.46967L7.46967 8.53033L10.9397 11.9997L7.46967 15.4697L8.53033 16.5303L11.9997 13.0597L15.4697 16.5303L16.5303 15.4697L13.0597 11.9997L16.5303 8.53033L15.4697 7.46967Z"
+                                        ></path>
+                                      </g>
+                                      <defs>
+                                        <clippath id="clip0_124_2957">
+                                          <rect width="24" height="24"></rect>
+                                        </clippath>
+                                      </defs>
+                                    </svg>
+                                    <div
+                                      data-v-524f63ea=""
+                                      class="inline-flex items-center"
+                                    >
+                                      <!---->
+                                    </div></button
+                                  ><!----></label
+                                ><!---->
+                              </div>
+                            </div>
+                          </div>
+
+                          <div
+                            data-v-4a727d65=""
+                            class="flex flex-row gap-[4px]"
+                          >
+                            <div
+                              data-v-4a727d65=""
+                              class="DeliveryForm__label"
+                            ></div>
+
+                            <!-- 집 -->
+                            <span
+                              data-v-43db7e7b=""
+                              data-v-4a727d65=""
+                              class="BaseChip__fill BaseChip--small BaseChip__fill--gray-f5 BaseChip"
+                              ><!---->
+                              <div
+                                data-v-cdfdef93=""
+                                data-v-43db7e7b=""
+                                class="BaseBadgeNotification__wrapper"
+                              >
+                                <div
+                                  data-v-9dbc8be1=""
+                                  data-v-43db7e7b=""
+                                  class="BaseFontVariable"
+                                >
+                                  <div
+                                    data-v-9dbc8be1=""
+                                    class="BaseFontVariable__text"
+                                  >
+                                    <span
+                                      data-v-9dbc8be1=""
+                                      class="BaseFontVariable__text--hidden"
+                                      >집</span
+                                    ><span
+                                      data-v-9dbc8be1=""
+                                      class="BaseFontVariable__text--display"
+                                      >집</span
+                                    >
+                                  </div>
+                                  <span
+                                    data-v-9dbc8be1=""
+                                    class="flex-auto inline-flex items-center"
+                                  ></span>
+                                </div>
+                                <!---->
+                              </div>
+                              <!---->
+                            </span>
+
+                            <!-- 회사 -->
+                            <span
+                              data-v-43db7e7b=""
+                              data-v-4a727d65=""
+                              class="BaseChip__fill BaseChip--small BaseChip__fill--gray-f5 BaseChip"
+                              ><!---->
+                              <div
+                                data-v-cdfdef93=""
+                                data-v-43db7e7b=""
+                                class="BaseBadgeNotification__wrapper"
+                              >
+                                <div
+                                  data-v-9dbc8be1=""
+                                  data-v-43db7e7b=""
+                                  class="BaseFontVariable"
+                                >
+                                  <div
+                                    data-v-9dbc8be1=""
+                                    class="BaseFontVariable__text"
+                                  >
+                                    <span
+                                      data-v-9dbc8be1=""
+                                      class="BaseFontVariable__text--hidden"
+                                      >회사</span
+                                    ><span
+                                      data-v-9dbc8be1=""
+                                      class="BaseFontVariable__text--display"
+                                      >회사</span
+                                    >
+                                  </div>
+                                  <span
+                                    data-v-9dbc8be1=""
+                                    class="flex-auto inline-flex items-center"
+                                  ></span>
+                                </div>
+                                <!---->
+                              </div>
+                              <!---->
+                            </span>
+
+                            <!-- 가족 -->
+                            <span
+                              data-v-43db7e7b=""
+                              data-v-4a727d65=""
+                              class="BaseChip__fill BaseChip--small BaseChip__fill--gray-f5 BaseChip"
+                              ><!---->
+                              <div
+                                data-v-cdfdef93=""
+                                data-v-43db7e7b=""
+                                class="BaseBadgeNotification__wrapper"
+                              >
+                                <div
+                                  data-v-9dbc8be1=""
+                                  data-v-43db7e7b=""
+                                  class="BaseFontVariable"
+                                >
+                                  <div
+                                    data-v-9dbc8be1=""
+                                    class="BaseFontVariable__text"
+                                  >
+                                    <span
+                                      data-v-9dbc8be1=""
+                                      class="BaseFontVariable__text--hidden"
+                                      >가족</span
+                                    ><span
+                                      data-v-9dbc8be1=""
+                                      class="BaseFontVariable__text--display"
+                                      >가족</span
+                                    >
+                                  </div>
+                                  <span
+                                    data-v-9dbc8be1=""
+                                    class="flex-auto inline-flex items-center"
+                                  ></span>
+                                </div>
+                                <!---->
+                              </div>
+                              <!---->
+                            </span>
+
+                            <!-- 친구 -->
+                            <span
+                              data-v-43db7e7b=""
+                              data-v-4a727d65=""
+                              class="BaseChip__fill BaseChip--small BaseChip__fill--gray-f5 BaseChip"
+                              ><!---->
+                              <div
+                                data-v-cdfdef93=""
+                                data-v-43db7e7b=""
+                                class="BaseBadgeNotification__wrapper"
+                              >
+                                <div
+                                  data-v-9dbc8be1=""
+                                  data-v-43db7e7b=""
+                                  class="BaseFontVariable"
+                                >
+                                  <div
+                                    data-v-9dbc8be1=""
+                                    class="BaseFontVariable__text"
+                                  >
+                                    <span
+                                      data-v-9dbc8be1=""
+                                      class="BaseFontVariable__text--hidden"
+                                      >친구</span
+                                    ><span
+                                      data-v-9dbc8be1=""
+                                      class="BaseFontVariable__text--display"
+                                      >친구</span
+                                    >
+                                  </div>
+                                  <span
+                                    data-v-9dbc8be1=""
+                                    class="flex-auto inline-flex items-center"
+                                  ></span>
+                                </div>
+                                <!---->
+                              </div>
+                              <!---->
+                            </span>
+                          </div>
+                          <!-- 기본 배송지 체크박스 -->
+                          <div data-v-4a727d65="">
+                            <label
+                              for="defaultAddressCheckbox"
+                              data-v-ee180726=""
+                              data-v-4a727d65=""
+                              class="BaseCheckbox BaseCheckbox__size--small BaseCheckbox__verticalAlign--center BaseCheckbox__state--unChecked"
+                              style="--BaseCheckbox--label-margin: 4"
+                            >
+                              <div
+                                data-v-ee180726=""
+                                class="BaseCheckbox__wrapper"
+                              >
+                                <input
+                                  id="defaultAddressCheckbox"
+                                  v-model="address.isDefault"
+                                  data-v-ee180726=""
+                                  class="BaseCheckbox__input"
+                                  type="checkbox"
+                                /><span
+                                  data-v-ee180726=""
+                                  class="BaseCheckbox__button"
+                                  ><svg
+                                    data-v-6d2bd019=""
+                                    data-v-ee180726=""
+                                    width="24"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    class="BaseIcon BaseCheckbox__icon"
+                                    style="
+                                      width: 24px;
+                                      height: 24px;
+                                      opacity: 1;
+                                      fill: currentcolor;
+                                      --BaseIcon-color: #d9d9d9;
+                                    "
+                                  >
+                                    <g clip-path="url(#clip0_2582_8708)">
+                                      <path
+                                        fill-rule="evenodd"
+                                        clip-rule="evenodd"
+                                        d="M7.76086 11.5393L10.1343 13.9131L16.2648 7.7827L17.3255 8.84336L10.6648 15.504C10.3964 15.7725 9.97496 15.7948 9.68099 15.5711L9.60419 15.504L6.7002 12.6L7.76086 11.5393Z"
+                                      ></path>
+                                    </g>
+                                    <defs>
+                                      <clippath id="clip0_2582_8708">
+                                        <rect width="24" height="24"></rect>
+                                      </clippath>
+                                    </defs></svg></span
+                                ><span
+                                  data-v-ee180726=""
+                                  class="BaseCheckbox__text"
+                                  style="color: rgb(51, 51, 51)"
+                                  >기본배송지로 설정</span
+                                >
+                              </div>
+                            </label>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <!-- 무슨 버튼인지 모르겠음 -->
+                  <button
+                    data-v-cdb47598=""
+                    data-v-60bedabc=""
+                    type="button"
+                    class="BaseButtonFab BaseButtonFab--small BaseButtonFab__icon--small !absolute BaseDialog__moveTop"
+                    style="--BaseButtonFab-color: #333333; display: none"
+                  >
+                    <svg
+                      data-v-6d2bd019=""
+                      data-v-cdb47598=""
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      xmlns="http://www.w3.org/2000/svg"
+                      class="BaseIcon BaseButtonFab__icon"
+                      style="
+                        width: 20px;
+                        height: 20px;
+                        opacity: 1;
+                        fill: currentcolor;
+                        --BaseIcon-color: #333333;
+                      "
+                    >
+                      <g clip-path="url(#clip0_124_2944)">
+                        <path
+                          d="M3.96869 11.7197L11.4687 4.21967C11.7616 3.92678 12.2365 3.92678 12.5293 4.21967L20.0293 11.7197L18.9687 12.7803L12.749 6.5606V20H11.249V6.56072L5.02935 12.7803L3.96869 11.7197Z"
+                        ></path>
+                      </g>
+                      <defs>
+                        <clippath id="clip0_124_2944">
+                          <rect width="24" height="24"></rect>
+                        </clippath>
+                      </defs>
+                    </svg>
+                  </button>
+
+                  <div
+                    data-v-60bedabc=""
+                    class="px-[16px] flex justify-center shrink-0 overflow-y-auto BaseDialog__footer--divider py-[8px]"
+                  >
+                    <div
+                      data-v-60bedabc=""
+                      class="grow BaseDialog__footerWrapper--fixed"
+                    >
+                      <div class="flex grow">
+                        <button
+                          @click="cancel"
+                          data-v-524f63ea=""
+                          data-v-7940d6dd=""
+                          type="outline"
+                          class="CoreButton CoreButton--block BaseButtonRectangle body1-bold-small BaseButtonRectangle__outline mr-[8px]"
+                          style="
+                            background-color: rgb(255, 255, 255);
+                            color: rgb(51, 51, 51);
+                            height: 40px;
+                            flex-direction: row;
+                            --core-button-padding-x: 16;
+                            --button-rectangle-border-color: #acacac;
+                          "
+                        >
+                          <!----><!---->
+                          <div
+                            data-v-524f63ea=""
+                            class="inline-flex items-center"
+                          >
+                            <span data-v-524f63ea="" class="CoreButton__text"
+                              >취소</span
+                            >
+                          </div>
+                        </button>
+                        <button
+                          @click="addAddress"
+                          data-v-524f63ea=""
+                          data-v-7940d6dd=""
+                          type="fill"
+                          class="CoreButton CoreButton--block BaseButtonRectangle body1-bold-small BaseButtonRectangle__fill"
+                          style="
+                            background-color: rgb(239, 112, 20);
+                            color: rgb(255, 255, 255);
+                            height: 40px;
+                            flex-direction: row;
+                            --core-button-padding-x: 16;
+                          "
+                        >
+                          <!----><!---->
+                          <div
+                            data-v-524f63ea=""
+                            class="inline-flex items-center"
+                          >
+                            <span data-v-524f63ea="" class="CoreButton__text"
+                              >저장</span
+                            >
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!---->
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref } from 'vue';
+import { useDeliveryStore } from '@/stores/useDeliveryStore';
+
+export default {
+  setup(props, { emit }) {
+    const deliveryStore = useDeliveryStore();
+    const address = ref({
+      recipient: '',
+      address: '',
+      detailAddress: '',
+      addressName: '',
+      postCode: '',
+      cellPhone: '',
+      isDefault: false,
+    });
+
+    const openPostcode = () => {
+      new window.daum.Postcode({
+        oncomplete: function (data) {
+          // 선택한 주소 정보를 address에 업데이트
+          address.value.address = data.address; // 도로명 주소
+          address.value.postCode = data.zonecode; // 우편번호
+          console.log('선택한 주소:', data.address);
+          console.log('우편번호:', data.zonecode);
+        },
+      }).open();
+    };
+
+    const addAddress = async () => {
+      try {
+        console.log(address.value);
+        await deliveryStore.addAddress(address.value);
+        emit('address-added');
+        emit('close');
+      } catch (error) {
+        console.error('Error adding address:', error);
+      }
+    };
+    const cancel = () => {
+      emit('close'); // 취소 버튼 클릭 시 모달 닫기
+    };
+
+    return {
+      openPostcode,
+      address,
+      addAddress,
+      cancel,
+    };
+  },
+};
+</script>

--- a/frontend/src/components/member/DeliveryComponent.vue
+++ b/frontend/src/components/member/DeliveryComponent.vue
@@ -1,12 +1,11 @@
 <template>
-  <div class="appContainer">
-    <div class="w-full pl-6">
-      <div>
-        <div class="flex justify-between pb-[24px]">
-          <h2 class="headline4-bold-small gray-333--text">배송지 관리</h2>
-          <div>
-            <!--배송지 추가 버튼-->
-            <button
+  <div class="w-full pl-6">
+    <div>
+      <div class="flex justify-between pb-[24px]">
+        <h2 class="headline4-bold-small gray-333--text">배송지 관리</h2>
+        <div>
+          <!--배송지 추가 버튼-->
+          <button
               @click="openModal"
               data-v-524f63ea=""
               data-v-7940d6dd=""
@@ -20,9 +19,9 @@
                 --core-button-padding-x: 16;
                 --button-rectangle-border-color: #ef7014;
               "
-            >
-              <!---->
-              <svg
+          >
+            <!---->
+            <svg
                 data-v-6d2bd019=""
                 data-v-524f63ea=""
                 width="24"
@@ -38,45 +37,46 @@
                   --BaseIcon-color: #333333;
                   margin-right: 2px;
                 "
-              >
-                <g clip-path="url(#clip0_124_2960)">
-                  <path
+            >
+              <g clip-path="url(#clip0_124_2960)">
+                <path
                     fill-rule="evenodd"
                     clip-rule="evenodd"
                     d="M12.75 5V11.25H19V12.75H12.75V19H11.25V12.75H5V11.25H11.25V5H12.75Z"
-                  ></path>
-                </g>
-                <defs>
-                  <clippath id="clip0_124_2960">
-                    <rect width="24" height="24"></rect>
-                  </clippath>
-                </defs>
-              </svg>
-              <div data-v-524f63ea="" class="inline-flex items-center">
+                ></path>
+              </g>
+              <defs>
+                <clippath id="clip0_124_2960">
+                  <rect width="24" height="24"></rect>
+                </clippath>
+              </defs>
+            </svg>
+            <div data-v-524f63ea="" class="inline-flex items-center">
                 <span data-v-524f63ea="" class="CoreButton__text"
-                  >배송지 추가하기</span
+                >배송지 추가하기</span
                 >
-              </div></button
-            ><!---->
-          </div>
-          <AddAddressComponent
+            </div>
+          </button
+          ><!---->
+        </div>
+        <AddAddressComponent
             v-if="isModalVisible"
             @close="closeModal"
             @address-added="fetchAddresses"
-          />
-        </div>
-        <!--      배송지 없을 때, 띄워주는 div-->
-        <div
+        />
+      </div>
+      <!--      배송지 없을 때, 띄워주는 div-->
+      <div
           class="flex flex-col items-center justify-center h-[640px]"
           button-width="328"
           style="display: none"
-        >
-          <div class="subtitle3_bold_medium">등록된 배송지가 없습니다.</div>
-          <div class="body1_regular_medium mt-[8px] mb-[16px]">
-            배송지 추가하기 버튼을 눌러 주소를 입력해주세요.
-          </div>
-          <div>
-            <button
+      >
+        <div class="subtitle3_bold_medium">등록된 배송지가 없습니다.</div>
+        <div class="body1_regular_medium mt-[8px] mb-[16px]">
+          배송지 추가하기 버튼을 눌러 주소를 입력해주세요.
+        </div>
+        <div>
+          <button
               data-v-524f63ea=""
               data-v-7940d6dd=""
               type="outline"
@@ -89,9 +89,9 @@
                 --core-button-padding-x: 16;
                 --button-rectangle-border-color: #ef7014;
               "
-            >
-              <!---->
-              <svg
+          >
+            <!---->
+            <svg
                 data-v-6d2bd019=""
                 data-v-524f63ea=""
                 width="24"
@@ -107,43 +107,44 @@
                   --BaseIcon-color: #333333;
                   margin-right: 2px;
                 "
-              >
-                <g clip-path="url(#clip0_124_2960)">
-                  <path
+            >
+              <g clip-path="url(#clip0_124_2960)">
+                <path
                     fill-rule="evenodd"
                     clip-rule="evenodd"
                     d="M12.75 5V11.25H19V12.75H12.75V19H11.25V12.75H5V11.25H11.25V5H12.75Z"
-                  ></path>
-                </g>
-                <defs>
-                  <clippath id="clip0_124_2960">
-                    <rect width="24" height="24"></rect>
-                  </clippath>
-                </defs>
-              </svg>
-              <div data-v-524f63ea="" class="inline-flex items-center">
+                ></path>
+              </g>
+              <defs>
+                <clippath id="clip0_124_2960">
+                  <rect width="24" height="24"></rect>
+                </clippath>
+              </defs>
+            </svg>
+            <div data-v-524f63ea="" class="inline-flex items-center">
                 <span data-v-524f63ea="" class="CoreButton__text"
-                  >배송지 추가하기</span
+                >배송지 추가하기</span
                 >
-              </div></button
-            ><!---->
-          </div>
+            </div>
+          </button
+          ><!---->
         </div>
+      </div>
 
-        <div
+      <div
           class="flex flex-col w-full rounded-sm border px-[16px] pt-[20px] pb-[8px] mb-[12px] last:mt-0"
-        >
-          <!-- 요게 반복       -->
-          <div
+      >
+        <!-- 요게 반복       -->
+        <div
             v-for="address in deliveryStore.addresses"
             :key="address.deliveryAddressIdx"
-            style="border: 0 solid #e5e7eb"
+            style="border: 1px solid rgb(229, 231, 235); padding: 20px 8px 16px 16px; margin-bottom: 12px"
             class="flex flex-col w-full"
-          >
-            <div class="w-full flex flex-col gap-[8px]">
-              <div class="flex">
-                <!--              기본 배송지 일 떄 기본 배송지 태그 붙여줌-->
-                <div
+        >
+          <div class="w-full flex flex-col gap-[8px]">
+            <div class="flex">
+              <!--              기본 배송지 일 떄 기본 배송지 태그 붙여줌-->
+              <div
                   v-if="address.isDefault"
                   data-v-24a9185e=""
                   class="BaseBadgeBusiness BaseBadgeBusiness__colorType--orange-500 BaseBadgeBusiness__size--medium mr-[4px] flex-none"
@@ -152,33 +153,33 @@
                     color: rgb(239, 112, 20);
                     background-color: rgb(255, 247, 242);
                   "
-                >
-                  <!---->
-                  기본배송지
-                </div>
+              >
+                <!---->
+                기본배송지
+              </div>
 
-                <!--              배송지 이름-->
-                <div class="flex break-all">
-                  <div class="body1-bold-small">
-                    {{ address.addressName }}
-                    <!---->
-                  </div>
+              <!--              배송지 이름-->
+              <div class="flex break-all">
+                <div class="body1-bold-small">
+                  {{ address.recipient }} ({{ address.addressName }})
+                  <!---->
                 </div>
               </div>
-              <!--            전화번호-->
-              <p class="body1-regular-medium text-left">
-                {{ address.cellPhone }}
-              </p>
-              <!--            주소-->
-              <p class="body1-regular-medium text-left break-all">
-                ({{ address.postCode }}) {{ address.address }} ({{
-                  address.detailAddress
-                }})
-              </p>
             </div>
-            <div class="flex justify-end mt-[4px]">
-              <!--            삭제 버튼-->
-              <button
+            <!--            전화번호-->
+            <p class="body1-regular-medium text-left">
+              {{ address.cellPhone }}
+            </p>
+            <!--            주소-->
+            <p class="body1-regular-medium text-left break-all">
+              ({{ address.postCode }}) {{ address.address }} ({{
+                address.detailAddress
+              }})
+            </p>
+          </div>
+          <div class="flex justify-end mt-[4px]">
+            <!--            삭제 버튼-->
+            <button
                 @click="deleteDeliveryAddress(address.id)"
                 data-v-524f63ea=""
                 data-v-8493c3f2=""
@@ -192,14 +193,14 @@
                   --core-button-padding-x: 8;
                   font-weight: bold;
                 "
-              >
-                <!----><!---->
-                <div data-v-524f63ea="" class="inline-flex items-center">
-                  <span data-v-524f63ea="" class="CoreButton__text">삭제</span>
-                </div>
-              </button>
-              <!--            수정 버튼-->
-              <button
+            >
+              <!----><!---->
+              <div data-v-524f63ea="" class="inline-flex items-center">
+                <span data-v-524f63ea="" class="CoreButton__text">삭제</span>
+              </div>
+            </button>
+            <!--            수정 버튼-->
+            <button
                 data-v-524f63ea=""
                 data-v-8493c3f2=""
                 type="default"
@@ -212,15 +213,14 @@
                   --core-button-padding-x: 8;
                   font-weight: bold;
                 "
-              >
-                <!----><!---->
-                <div data-v-524f63ea="" class="inline-flex items-center">
-                  <span data-v-524f63ea="" class="CoreButton__text">수정</span>
-                </div>
-              </button>
-            </div>
-            <!---->
+            >
+              <!----><!---->
+              <div data-v-524f63ea="" class="inline-flex items-center">
+                <span data-v-524f63ea="" class="CoreButton__text">수정</span>
+              </div>
+            </button>
           </div>
+          <!---->
         </div>
       </div>
     </div>
@@ -228,8 +228,8 @@
 </template>
 
 <script>
-import { ref, onMounted } from 'vue';
-import { useDeliveryStore } from '@/stores/useDeliveryStore';
+import {onMounted, ref} from 'vue';
+import {useDeliveryStore} from '@/stores/useDeliveryStore';
 import AddAddressComponent from './AddAddressComponent.vue';
 
 export default {

--- a/frontend/src/components/member/DeliveryComponent.vue
+++ b/frontend/src/components/member/DeliveryComponent.vue
@@ -1,0 +1,269 @@
+<template>
+  <div class="appContainer">
+    <div class="w-full pl-6">
+      <div>
+        <div class="flex justify-between pb-[24px]">
+          <h2 class="headline4-bold-small gray-333--text">배송지 관리</h2>
+          <div>
+            <!--배송지 추가 버튼-->
+            <button
+              @click="openModal"
+              data-v-524f63ea=""
+              data-v-7940d6dd=""
+              type="outline"
+              class="CoreButton BaseButtonRectangle body1-bold-small BaseButtonRectangle__outline"
+              style="
+                background-color: rgb(255, 255, 255);
+                color: rgb(239, 112, 20);
+                height: 40px;
+                flex-direction: row;
+                --core-button-padding-x: 16;
+                --button-rectangle-border-color: #ef7014;
+              "
+            >
+              <!---->
+              <svg
+                data-v-6d2bd019=""
+                data-v-524f63ea=""
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+                class="BaseIcon CoreButton__icon"
+                style="
+                  width: 18px;
+                  height: 18px;
+                  opacity: 1;
+                  fill: currentcolor;
+                  --BaseIcon-color: #333333;
+                  margin-right: 2px;
+                "
+              >
+                <g clip-path="url(#clip0_124_2960)">
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M12.75 5V11.25H19V12.75H12.75V19H11.25V12.75H5V11.25H11.25V5H12.75Z"
+                  ></path>
+                </g>
+                <defs>
+                  <clippath id="clip0_124_2960">
+                    <rect width="24" height="24"></rect>
+                  </clippath>
+                </defs>
+              </svg>
+              <div data-v-524f63ea="" class="inline-flex items-center">
+                <span data-v-524f63ea="" class="CoreButton__text"
+                  >배송지 추가하기</span
+                >
+              </div></button
+            ><!---->
+          </div>
+          <AddAddressComponent
+            v-if="isModalVisible"
+            @close="closeModal"
+            @address-added="fetchAddresses"
+          />
+        </div>
+        <!--      배송지 없을 때, 띄워주는 div-->
+        <div
+          class="flex flex-col items-center justify-center h-[640px]"
+          button-width="328"
+          style="display: none"
+        >
+          <div class="subtitle3_bold_medium">등록된 배송지가 없습니다.</div>
+          <div class="body1_regular_medium mt-[8px] mb-[16px]">
+            배송지 추가하기 버튼을 눌러 주소를 입력해주세요.
+          </div>
+          <div>
+            <button
+              data-v-524f63ea=""
+              data-v-7940d6dd=""
+              type="outline"
+              class="CoreButton CoreButton--block BaseButtonRectangle body1-bold-small BaseButtonRectangle__outline"
+              style="
+                background-color: rgb(255, 255, 255);
+                color: rgb(239, 112, 20);
+                height: 40px;
+                flex-direction: row;
+                --core-button-padding-x: 16;
+                --button-rectangle-border-color: #ef7014;
+              "
+            >
+              <!---->
+              <svg
+                data-v-6d2bd019=""
+                data-v-524f63ea=""
+                width="24"
+                height="24"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+                class="BaseIcon CoreButton__icon"
+                style="
+                  width: 18px;
+                  height: 18px;
+                  opacity: 1;
+                  fill: currentcolor;
+                  --BaseIcon-color: #333333;
+                  margin-right: 2px;
+                "
+              >
+                <g clip-path="url(#clip0_124_2960)">
+                  <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M12.75 5V11.25H19V12.75H12.75V19H11.25V12.75H5V11.25H11.25V5H12.75Z"
+                  ></path>
+                </g>
+                <defs>
+                  <clippath id="clip0_124_2960">
+                    <rect width="24" height="24"></rect>
+                  </clippath>
+                </defs>
+              </svg>
+              <div data-v-524f63ea="" class="inline-flex items-center">
+                <span data-v-524f63ea="" class="CoreButton__text"
+                  >배송지 추가하기</span
+                >
+              </div></button
+            ><!---->
+          </div>
+        </div>
+
+        <div
+          class="flex flex-col w-full rounded-sm border px-[16px] pt-[20px] pb-[8px] mb-[12px] last:mt-0"
+        >
+          <!-- 요게 반복       -->
+          <div
+            v-for="address in deliveryStore.addresses"
+            :key="address.deliveryAddressIdx"
+            style="border: 0 solid #e5e7eb"
+            class="flex flex-col w-full"
+          >
+            <div class="w-full flex flex-col gap-[8px]">
+              <div class="flex">
+                <!--              기본 배송지 일 떄 기본 배송지 태그 붙여줌-->
+                <div
+                  v-if="address.isDefault"
+                  data-v-24a9185e=""
+                  class="BaseBadgeBusiness BaseBadgeBusiness__colorType--orange-500 BaseBadgeBusiness__size--medium mr-[4px] flex-none"
+                  style="
+                    font-weight: bold;
+                    color: rgb(239, 112, 20);
+                    background-color: rgb(255, 247, 242);
+                  "
+                >
+                  <!---->
+                  기본배송지
+                </div>
+
+                <!--              배송지 이름-->
+                <div class="flex break-all">
+                  <div class="body1-bold-small">
+                    {{ address.addressName }}
+                    <!---->
+                  </div>
+                </div>
+              </div>
+              <!--            전화번호-->
+              <p class="body1-regular-medium text-left">
+                {{ address.cellPhone }}
+              </p>
+              <!--            주소-->
+              <p class="body1-regular-medium text-left break-all">
+                ({{ address.postCode }}) {{ address.address }} ({{
+                  address.detailAddress
+                }})
+              </p>
+            </div>
+            <div class="flex justify-end mt-[4px]">
+              <!--            삭제 버튼-->
+              <button
+                @click="deleteDeliveryAddress(address.id)"
+                data-v-524f63ea=""
+                data-v-8493c3f2=""
+                type="default"
+                class="CoreButton BaseButtonText body3-regular-small"
+                style="
+                  background-color: transparent;
+                  color: rgb(102, 102, 102);
+                  height: 30px;
+                  flex-direction: row-reverse;
+                  --core-button-padding-x: 8;
+                  font-weight: bold;
+                "
+              >
+                <!----><!---->
+                <div data-v-524f63ea="" class="inline-flex items-center">
+                  <span data-v-524f63ea="" class="CoreButton__text">삭제</span>
+                </div>
+              </button>
+              <!--            수정 버튼-->
+              <button
+                data-v-524f63ea=""
+                data-v-8493c3f2=""
+                type="default"
+                class="CoreButton BaseButtonText body3-regular-small ml-[12px]"
+                style="
+                  background-color: transparent;
+                  color: rgb(102, 102, 102);
+                  height: 30px;
+                  flex-direction: row-reverse;
+                  --core-button-padding-x: 8;
+                  font-weight: bold;
+                "
+              >
+                <!----><!---->
+                <div data-v-524f63ea="" class="inline-flex items-center">
+                  <span data-v-524f63ea="" class="CoreButton__text">수정</span>
+                </div>
+              </button>
+            </div>
+            <!---->
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, onMounted } from 'vue';
+import { useDeliveryStore } from '@/stores/useDeliveryStore';
+import AddAddressComponent from './AddAddressComponent.vue';
+
+export default {
+  components: {
+    AddAddressComponent,
+  },
+
+  setup() {
+    const deliveryStore = useDeliveryStore();
+    const isModalVisible = ref(false);
+
+    const openModal = () => {
+      isModalVisible.value = true;
+    };
+
+    const closeModal = () => {
+      isModalVisible.value = false;
+    };
+
+    const fetchAddresses = () => {
+      deliveryStore.fetchAddresses();
+    };
+
+    onMounted(() => {
+      fetchAddresses();
+    });
+
+    return {
+      openModal,
+      fetchAddresses,
+      closeModal,
+      deliveryStore,
+      isModalVisible,
+    };
+  },
+};
+</script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,11 +1,19 @@
-import { createRouter, createWebHistory } from "vue-router";
-import App from "@/App";
+import { createRouter, createWebHistory } from 'vue-router';
+import App from '@/App';
+import DeliveryComponent from '@/components/member/DeliveryComponent.vue';
 
 const router = createRouter({
-    history: createWebHistory(),
-    routes: [
-        { path: "/", component: App },
-    ],
+  history: createWebHistory(),
+  routes: [
+    {
+      path: '/',
+      component: App,
+    },
+    {
+      path: '/deliveryAddress',
+      component: DeliveryComponent,
+    },
+  ],
 });
 
 export default router;

--- a/frontend/src/stores/useDeliveryStore.js
+++ b/frontend/src/stores/useDeliveryStore.js
@@ -1,0 +1,32 @@
+import { defineStore } from 'pinia';
+import axios from 'axios';
+
+export const useDeliveryStore = defineStore('delivery', {
+  state: () => ({
+    addresses: [],
+  }),
+  actions: {
+    async fetchAddresses() {
+      try {
+        const response = await axios.get(
+          '/api/member/deliveryAddressList?userIdx=1'
+        );
+
+        console.log('Response:', response.data);
+        this.addresses = response.data.result;
+      } catch (error) {
+        console.error('Error fetching addresses:', error);
+      }
+    },
+    async addAddress(address) {
+      console.log(address);
+      try {
+        let response = await axios.post('/api/member/deliveryAddress', address);
+        await this.fetchAddresses();
+        return response.data;
+      } catch (error) {
+        console.error('Error adding address:', error);
+      }
+    },
+  },
+});

--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,14 +1,14 @@
-const { defineConfig } = require('@vue/cli-service')
+const { defineConfig } = require('@vue/cli-service');
 module.exports = defineConfig({
-  devServer:{
-    port : 3000,
-    proxy:{
-      "/api":{
-        target:"http://localhost:8080", //localhost:8080
+  devServer: {
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080', //localhost:8080
         changeOrigin: true,
-        pathRewrite:{"^/api": ""},
-      }
-    }
+        pathRewrite: { '^/api': '' },
+      },
+    },
   },
-  transpileDependencies: true
-})
+  transpileDependencies: true,
+});


### PR DESCRIPTION
## 📚이슈 번호
#68 

## 📃요약
배송지 조회 컴포넌트
배송지 추가 모달 컴포넌트 

<br><br>

## 💪작업 상세 내용
배송지 리스트 조회 컴포넌트
리스트를 조회하며 배송지 추가 모달을 닫아도 다시 조회를 할 수 있도록 설정했습니다.
리스트를 감싸고 있는 border 설정은 직접 style 설정해줬는데 이후 다른 컴포넌트와 같이 사용했을 때 문제가 발생한다면 수정 예정입니다.

배송지 추가 모달 컴포넌트
daum api를 통해서 주소를 가져오도록 했습니다.
하단의 기본배송지 체크박스를 누르면 실제 눌러지지만, 표시가 안되는 상황이라 이후 장바구니 체크박스 설정하면서 변경하도록 하겠습니다. 


<br><br>

## 🙇‍♀ 전달사항
![image](https://github.com/user-attachments/assets/f9a577d8-e70f-48eb-a6d7-62f19d7d4e0b)
프론트 부분 값 검증이 아직 미흡합니다. 이후에 수정하도록 하겠습니다.

<br><br>

## 💭참고 자료
.

<br><br>
