### PR TITLE
[Feat]상품 카테고리 검색 기능 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -28,6 +28,14 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	//queryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	implementation "com.querydsl:querydsl-core"
+	implementation "com.querydsl:querydsl-collections"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api" // java.lang.NoClassDefFoundError (javax.annotation.Generated) 에러 대응 코드
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api" // java.lang.NoClassDefFoundError (javax.annotation.Entity) 에러 대응 코드
+
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/synergy/backend/atelier/model/entity/Atelier.java
+++ b/backend/src/main/java/com/synergy/backend/atelier/model/entity/Atelier.java
@@ -2,8 +2,10 @@ package com.synergy.backend.atelier.model.entity;
 
 import com.synergy.backend.common.model.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
+@Getter
 @Table(name = "atelier")
 public class Atelier extends BaseEntity {
 

--- a/backend/src/main/java/com/synergy/backend/product/controller/ProductController.java
+++ b/backend/src/main/java/com/synergy/backend/product/controller/ProductController.java
@@ -1,0 +1,22 @@
+package com.synergy.backend.product.controller;
+
+import com.synergy.backend.product.model.dto.response.SearchProductRes;
+import com.synergy.backend.product.service.ProductService;
+import com.synergy.backend.product.model.entity.Product;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProductController {
+    private final ProductService productService;
+
+    @GetMapping("/search")
+    public ResponseEntity<List<SearchProductRes>> search(Long categoryIdx){
+        List<SearchProductRes> result = productService.search(categoryIdx);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/product/model/dto/response/SearchProductRes.java
+++ b/backend/src/main/java/com/synergy/backend/product/model/dto/response/SearchProductRes.java
@@ -1,0 +1,18 @@
+package com.synergy.backend.product.model.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SearchProductRes {
+    Long idx;
+    String name;
+    int price;
+    String thumbnailUrl;
+    Double averageScore;
+    String atelier_name;
+    String category_name;
+
+
+}

--- a/backend/src/main/java/com/synergy/backend/product/model/entity/Category.java
+++ b/backend/src/main/java/com/synergy/backend/product/model/entity/Category.java
@@ -1,8 +1,10 @@
 package com.synergy.backend.product.model.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
+@Getter
 @Table(name = "category")
 public class Category {
 

--- a/backend/src/main/java/com/synergy/backend/product/model/entity/Product.java
+++ b/backend/src/main/java/com/synergy/backend/product/model/entity/Product.java
@@ -3,8 +3,10 @@ package com.synergy.backend.product.model.entity;
 import com.synergy.backend.atelier.model.entity.Atelier;
 import com.synergy.backend.common.model.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
+@Getter
 @Table(name = "product")
 public class Product extends BaseEntity {
 

--- a/backend/src/main/java/com/synergy/backend/product/querydsl/ProductRepositoryCustom.java
+++ b/backend/src/main/java/com/synergy/backend/product/querydsl/ProductRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.synergy.backend.product.querydsl;
+
+import com.synergy.backend.product.model.entity.Product;
+import java.util.List;
+
+public interface ProductRepositoryCustom {
+    List<Product> findProductsByTopCategoryName(Long categoryIdx);
+}

--- a/backend/src/main/java/com/synergy/backend/product/querydsl/ProductRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/synergy/backend/product/querydsl/ProductRepositoryCustomImpl.java
@@ -1,0 +1,63 @@
+package com.synergy.backend.product.querydsl;
+
+import com.synergy.backend.product.model.entity.Product;
+import com.synergy.backend.product.model.entity.QCategory;
+import com.synergy.backend.product.model.entity.QProduct;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class ProductRepositoryCustomImpl implements ProductRepositoryCustom{
+    private final JPAQueryFactory queryFactory;
+    private QProduct product;
+    private QCategory category;
+
+    public ProductRepositoryCustomImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+        this.product = QProduct.product;
+        this.category = QCategory.category;
+    }
+
+    @Override
+    public List<Product> findProductsByTopCategoryName(Long categoryIdx) {
+        List<Long> categoryIds = findAllSubCategoryIds(categoryIdx);
+
+        return queryFactory
+                .select(product)
+                .from(product)
+                .where(product.category.idx.in(categoryIds))
+                .fetch();
+    }
+
+    private List<Long> findAllSubCategoryIds(Long parentCategoryIdx) {
+        List<Long> allCategoryIds = new ArrayList<>();
+        allCategoryIds.add(parentCategoryIdx);
+        //직접적으로 연결된 하위 카테고리 찾기
+        List<Long> subCategoryIds = findSubCategoryIds(parentCategoryIdx);
+
+        //모든 categoryIds에 대해 각각 다시 subcategories를 찾고 카테고리 목록에 추가하는 반복문
+        while(!subCategoryIds.isEmpty()){
+            List<Long> newIds = new ArrayList<>();
+            for (Long ids : subCategoryIds) {
+                allCategoryIds.add(ids);
+                newIds.addAll(findSubCategoryIds(ids));
+            }
+            subCategoryIds = newIds;
+        }
+
+        return allCategoryIds;
+    }
+    private List<Long> findSubCategoryIds(Long parentCategoryIdx) {
+        // 상위 카테고리와 직접적으로 연결된 하위 카테고리 찾기
+        List<Long> subCategoryIds = queryFactory
+                .select(category.idx)
+                .from(category)
+                .where(category.parentCategory.idx.eq(parentCategoryIdx))
+                .fetch();
+
+        return subCategoryIds;
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/synergy/backend/product/repository/ProductRepository.java
@@ -1,0 +1,8 @@
+package com.synergy.backend.product.repository;
+
+import com.synergy.backend.product.model.entity.Product;
+import com.synergy.backend.product.querydsl.ProductRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryCustom {
+}

--- a/backend/src/main/java/com/synergy/backend/product/service/ProductService.java
+++ b/backend/src/main/java/com/synergy/backend/product/service/ProductService.java
@@ -1,0 +1,34 @@
+package com.synergy.backend.product.service;
+
+import com.synergy.backend.product.model.dto.response.SearchProductRes;
+import com.synergy.backend.product.repository.ProductRepository;
+import com.synergy.backend.product.model.entity.Product;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+    private final ProductRepository productRepository;
+    public List<SearchProductRes> search(Long categoryIdx) {
+        List<Product> result = productRepository.findProductsByTopCategoryName(categoryIdx);
+
+        List<SearchProductRes> response = new ArrayList<>();
+
+        for (Product product : result) {
+            response.add(SearchProductRes.builder()
+                    .idx(product.getIdx())
+                    .name(product.getName())
+                    .price(product.getPrice())
+                    .averageScore(product.getAverageScore())
+//                    .atelier_name(product.getAtelier().getName())
+                    .category_name(product.getCategory().getCategoryName())
+                    .thumbnailUrl(product.getThumbnailUrl())
+                    .build());
+        }
+
+        return response;
+    }
+}


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->
#46

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->
카테고리 idx로 관련된 카테고리에 해당하는 상품을 조회하는 기능

<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->
- queryDSL 사용
- build.gradle에 queryDSL 관련된 dependency 추가했습니다. 따로 queryDSL라는 주석 밑에 추가했습니다.
- queryDSL관련된 레포지토리는 querydsl 패키지에 구분해놨습니다.
- Qclass 생성을 위한 build 필요 (방법은 하단의 '이슈/의논거리'에 설명 적어놨습니다.)

#### 간단한 로직 설명
1. 카테고리 테이블에서 요청받은 카테고리 idx와 관련된 카테고리 idx를 모두 찾는다. (e.g. 베이커리 -> 빵, 쿠키 등)
2. 1번에서 찾은 카테고리 범주에 해당하는 상품을 모두 찾는다.

#### 자기 참조 테이블 조회
depth가 정해지지 않은 자기참조 테이블(카테고리 테이블)에 대해 조회를 수행하기 위해서 처음에 재귀 방식을 사용했습니다.
하지만 재귀는 성능저하에 영향을 끼치기 때문에 반복문으로 다시 로직을 만들었습니다.


<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->
#### Qclass 생성 방법
build를 실행하면 아래 이미지(왼쪽)처럼 Qclass가 생성됩니다.
<img width="1510" alt="스크린샷 2024-09-09 오후 4 10 26" src="https://github.com/user-attachments/assets/b68b1f65-efc1-4d5c-9a3f-8e991226bf58">


<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
