### PR TITLE
[Refactor]카테고리 검색만 가능하던 쿼리dsl 레포지토리를 다른 검색에 사용할 수 있도록 리펙토링함

### DIFF
--- a/backend/src/main/java/com/synergy/backend/product/querydsl/ProductRepositoryCustom.java
+++ b/backend/src/main/java/com/synergy/backend/product/querydsl/ProductRepositoryCustom.java
@@ -4,5 +4,5 @@ import com.synergy.backend.product.model.entity.Product;
 import java.util.List;
 
 public interface ProductRepositoryCustom {
-    List<Product> findProductsByTopCategoryName(Long categoryIdx);
+    List<Product> search(Long categoryIdx);
 }

--- a/backend/src/main/java/com/synergy/backend/product/querydsl/ProductRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/synergy/backend/product/querydsl/ProductRepositoryCustomImpl.java
@@ -1,5 +1,6 @@
 package com.synergy.backend.product.querydsl;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.synergy.backend.product.model.entity.Product;
 import com.synergy.backend.product.model.entity.QCategory;
 import com.synergy.backend.product.model.entity.QProduct;
@@ -22,14 +23,22 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom{
     }
 
     @Override
-    public List<Product> findProductsByTopCategoryName(Long categoryIdx) {
-        List<Long> categoryIds = findAllSubCategoryIds(categoryIdx);
+    public List<Product> search(Long categoryIdx) {
 
         return queryFactory
-                .select(product)
-                .from(product)
-                .where(product.category.idx.in(categoryIds))
+                .selectFrom(product)
+                .leftJoin(product.category, category).fetchJoin()
+                .where(categoryEq(categoryIdx))
                 .fetch();
+    }
+
+    private BooleanExpression categoryEq(Long categoryIdx){
+        if(categoryIdx==null){
+            return null;
+        }
+
+        List<Long> categoryIds = findAllSubCategoryIds(categoryIdx);
+        return product.category.idx.in(categoryIds);
     }
 
     private List<Long> findAllSubCategoryIds(Long parentCategoryIdx) {

--- a/backend/src/main/java/com/synergy/backend/product/service/ProductService.java
+++ b/backend/src/main/java/com/synergy/backend/product/service/ProductService.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 public class ProductService {
     private final ProductRepository productRepository;
     public List<SearchProductRes> search(Long categoryIdx) {
-        List<Product> result = productRepository.findProductsByTopCategoryName(categoryIdx);
+        List<Product> result = productRepository.search(categoryIdx);
 
         List<SearchProductRes> response = new ArrayList<>();
 


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->
#해당사항 없음

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->
- 이전의 쿼리 dsl 레포지토리는 카테고리 검색만 가능했음.
- 카테고리 조회 외에도 다른 해시태그검색이나 검색어 검색 등의 기능을 함께 사용할 수 있도록 리펙토링 과정을 거쳤습니다.

<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->
- ```List<Long> categoryIds = findAllSubCategoryIds(categoryIdx)``` 관련 카테고리를 조회하는 코드를 categoryEq 메서드로 분리
- ```product.category.idx.in(categoryIds)``` 해당 코드 또한 categoryEq 메서드에 구현
- search 메서드의 where절에는 boolean값을 반환하는 메서드만 조건으로 추가함으로서 다른 조건을 추가할 수 있게됨.

<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->

<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
