### PR TITLE
[Feat] 상품 장바구니 추가, 수량 증가, 감소 

### DIFF
--- a/backend/src/main/java/com/synergy/backend/alert/model/entity/Alert.java
+++ b/backend/src/main/java/com/synergy/backend/alert/model/entity/Alert.java
@@ -1,4 +1,4 @@
-package com.synergy.backend.Alert.model.entity;
+package com.synergy.backend.alert.model.entity;
 
 import com.synergy.backend.common.model.BaseEntity;
 import com.synergy.backend.member.model.entity.Member;

--- a/backend/src/main/java/com/synergy/backend/common/BaseResponseStatus.java
+++ b/backend/src/main/java/com/synergy/backend/common/BaseResponseStatus.java
@@ -34,12 +34,14 @@ public enum BaseResponseStatus {
 
     NOT_FOUND_PRODUCT(false, 3000, "상품을 찾을 수 없습니다."),
     NOT_FOUND_PRODUCT_MAJOR_OPTIONS(false, 3001, "상품 대분류 옵션을 찾을 수 없습니다."),
-    NOT_FOUND_PRODUCT_SUB_OPTIONS(false, 3002, "상품 소분류 옵션을 찾을 수 없습니다.");
+    NOT_FOUND_PRODUCT_SUB_OPTIONS(false, 3002, "상품 소분류 옵션을 찾을 수 없습니다."),
 
     /**
      * 4000: 주문, 결제
-     *
      */
+    NOT_FOUND_CART(false, 4000, "장바구니가 존재하지 않습니다."),
+    COUNT_BELOW_ZERO(false, 4001, "수량은 0개가 될 수 없습니다."),
+    EXCEEDS_MAX_COUNT(false, 4002, "지정된 수량 이상 선택할 수 없습니다.");
 
 
     /**
@@ -65,4 +67,4 @@ public enum BaseResponseStatus {
         this.code = code;
         this.message = message;
     }
-    }
+}

--- a/backend/src/main/java/com/synergy/backend/common/BaseResponseStatus.java
+++ b/backend/src/main/java/com/synergy/backend/common/BaseResponseStatus.java
@@ -25,16 +25,20 @@ public enum BaseResponseStatus {
      * 2000: 유저, 등급, 팔로우
      */
     NOT_FOUND_USER(false, 2000, "유저를 찾을 수 없습니다."),
-    REQUIRED_VALUE_NOT_ENTERED(false, 2001, "필수값이 모두 입력되지 않았습니다.");
+    REQUIRED_VALUE_NOT_ENTERED(false, 2001, "필수값이 모두 입력되지 않았습니다."),
 
 
     /**
      * 3000: 상품, 카테고리
      */
 
+    NOT_FOUND_PRODUCT(false, 3000, "상품을 찾을 수 없습니다."),
+    NOT_FOUND_PRODUCT_MAJOR_OPTIONS(false, 3001, "상품 대분류 옵션을 찾을 수 없습니다."),
+    NOT_FOUND_PRODUCT_SUB_OPTIONS(false, 3002, "상품 소분류 옵션을 찾을 수 없습니다.");
 
     /**
      * 4000: 주문, 결제
+     *
      */
 
 
@@ -61,4 +65,4 @@ public enum BaseResponseStatus {
         this.code = code;
         this.message = message;
     }
-}
+    }

--- a/backend/src/main/java/com/synergy/backend/member/controller/MemberController.java
+++ b/backend/src/main/java/com/synergy/backend/member/controller/MemberController.java
@@ -1,23 +1,17 @@
 package com.synergy.backend.member.controller;
 
 
-import com.synergy.backend.member.model.request.MemberSignupReq;
-import com.synergy.backend.member.service.MemberService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import com.synergy.backend.common.BaseException;
 import com.synergy.backend.common.BaseResponse;
 import com.synergy.backend.common.BaseResponseStatus;
 import com.synergy.backend.member.model.request.CreateDeliveryAddressReq;
+import com.synergy.backend.member.model.request.MemberSignupReq;
 import com.synergy.backend.member.model.response.DeliveryAddressRes;
 import com.synergy.backend.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
 
 
@@ -29,7 +23,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/signup")
-    public ResponseEntity<String> signup(@RequestBody MemberSignupReq memberSignupReq){
+    public ResponseEntity<String> signup(@RequestBody MemberSignupReq memberSignupReq) {
         String result = memberService.signup(memberSignupReq);
         return ResponseEntity.ok(result);
     }
@@ -44,16 +38,17 @@ public class MemberController {
     }
 
 
-    //배송지 목록 조회
+    //배송지 목록 조회 TODO 배송지 없으면 추가할 때 기본 배송지로 설정 ( 체크박스 비활성화 되도록 )
     @GetMapping("/deliveryAddressList")
     public BaseResponse<List<DeliveryAddressRes>> getDeliveryAddress(Long userIdx) throws BaseException {
         return new BaseResponse<>(memberService.getDeliveryAddressList(userIdx));
     }
 
 
-    //배송지 추가
+    //배송지 추가 TODO 배송지 없으면 기본 배송지로 설정하는 거
     @PostMapping("/deliveryAddress")
-    public BaseResponse<Void> createDeliveryAddress(@RequestBody CreateDeliveryAddressReq req, Long userIdx) throws BaseException {
+    public BaseResponse<Void> createDeliveryAddress(@RequestBody CreateDeliveryAddressReq req) throws BaseException {
+        Long userIdx = 1L;
         memberService.createDeliveryAddress(req, userIdx);
         return new BaseResponse<>(BaseResponseStatus.SUCCESS);
     }

--- a/backend/src/main/java/com/synergy/backend/member/service/MemberService.java
+++ b/backend/src/main/java/com/synergy/backend/member/service/MemberService.java
@@ -1,28 +1,22 @@
 package com.synergy.backend.member.service;
 
-import com.synergy.backend.member.model.entity.Member;
-import com.synergy.backend.member.model.request.MemberSignupReq;
-import com.synergy.backend.member.repository.MemberRepository;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.stereotype.Service;
 import com.synergy.backend.common.BaseException;
 import com.synergy.backend.common.BaseResponseStatus;
 import com.synergy.backend.member.model.entity.DeliveryAddress;
 import com.synergy.backend.member.model.entity.Member;
 import com.synergy.backend.member.model.request.CreateDeliveryAddressReq;
+import com.synergy.backend.member.model.request.MemberSignupReq;
 import com.synergy.backend.member.model.response.DeliveryAddressRes;
 import com.synergy.backend.member.repository.DeliveryAddressRepository;
 import com.synergy.backend.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.util.ArrayList;
-import java.util.Deque;
-import java.util.LinkedList;
-import java.util.List;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -35,14 +29,14 @@ public class MemberService {
     public String signup(MemberSignupReq memberSignupReq) {
         LocalDateTime localDateTime = LocalDateTime.now();
         localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
-        Member member = MemberSignupReq.toEntity(memberSignupReq,bCryptPasswordEncoder);
+        Member member = MemberSignupReq.toEntity(memberSignupReq, bCryptPasswordEncoder);
         Member result = memberRepository.save(member);
 
-        try{
-            if(result == null){
+        try {
+            if (result == null) {
                 throw new Exception("회원 저장이 잘못되었습니다.");
             }
-        }catch (Exception e){
+        } catch (Exception e) {
             return e.getMessage();
         }
 
@@ -77,7 +71,9 @@ public class MemberService {
     @Transactional
     public void createDeliveryAddress(CreateDeliveryAddressReq req, Long userIdx) throws BaseException {
         //필수값 필수!
-        if (req.getAddress() == null || req.getRecipient() == null || req.getCellPhone() == null) {
+        if (Objects.equals(req.getAddress(), "")
+                || Objects.equals(req.getRecipient(), "")
+                || Objects.equals(req.getCellPhone(), "")) {
             throw new BaseException(BaseResponseStatus.REQUIRED_VALUE_NOT_ENTERED);
         }
         Member member = getMember(userIdx);

--- a/backend/src/main/java/com/synergy/backend/orders/controller/CartController.java
+++ b/backend/src/main/java/com/synergy/backend/orders/controller/CartController.java
@@ -1,0 +1,42 @@
+package com.synergy.backend.orders.controller;
+
+import com.synergy.backend.common.BaseException;
+import com.synergy.backend.common.BaseResponse;
+import com.synergy.backend.common.BaseResponseStatus;
+import com.synergy.backend.global.security.CustomUserDetails;
+import com.synergy.backend.orders.model.request.AddCartReq;
+import com.synergy.backend.orders.service.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/cart")
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartService cartService;
+
+    // 새로운 상품 카트에 추가
+    @PostMapping
+    public BaseResponse<Void> addCart(@RequestBody AddCartReq req,
+                                      @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
+        cartService.addCart(customUserDetails.getIdx(), req);
+        return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+    }
+
+
+    //상품 수량 감소
+
+
+    // 상품 목록 조회
+
+
+    // 상품 검증
+
+
+    // 선택 상품 주문은 pinia를 통해
+}

--- a/backend/src/main/java/com/synergy/backend/orders/controller/CartController.java
+++ b/backend/src/main/java/com/synergy/backend/orders/controller/CartController.java
@@ -5,13 +5,11 @@ import com.synergy.backend.common.BaseResponse;
 import com.synergy.backend.common.BaseResponseStatus;
 import com.synergy.backend.global.security.CustomUserDetails;
 import com.synergy.backend.orders.model.request.AddCartReq;
+import com.synergy.backend.orders.model.request.IncreaseProductReq;
 import com.synergy.backend.orders.service.CartService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/cart")
@@ -28,11 +26,24 @@ public class CartController {
         return new BaseResponse<>(BaseResponseStatus.SUCCESS);
     }
 
+    // 중복 상품일 때 상품 수량 증가
+    @PostMapping("/increase")
+    public BaseResponse<Void> increase(@RequestBody IncreaseProductReq req,
+                                       @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
+        cartService.increase(req.getCartIdx());
+        return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+    }
 
     //상품 수량 감소
-
+    @PostMapping("/decrease")
+    public BaseResponse<Void> decrease(@RequestBody IncreaseProductReq req,
+                                       @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
+        cartService.decrease(req.getCartIdx());
+        return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+    }
 
     // 상품 목록 조회
+
 
 
     // 상품 검증

--- a/backend/src/main/java/com/synergy/backend/orders/model/entity/Cart.java
+++ b/backend/src/main/java/com/synergy/backend/orders/model/entity/Cart.java
@@ -4,21 +4,33 @@ import com.synergy.backend.common.model.BaseEntity;
 import com.synergy.backend.member.model.entity.Member;
 import com.synergy.backend.product.model.entity.Product;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "cart")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Cart extends BaseEntity {
+
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_idx")
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_idx")
     private Product product;
 
+    @Column(nullable = false)
     private Long count;
+
+    @Column(nullable = false)
+    private Integer price;
 
 }

--- a/backend/src/main/java/com/synergy/backend/orders/model/entity/Cart.java
+++ b/backend/src/main/java/com/synergy/backend/orders/model/entity/Cart.java
@@ -1,16 +1,20 @@
 package com.synergy.backend.orders.model.entity;
 
+import com.synergy.backend.common.BaseException;
+import com.synergy.backend.common.BaseResponseStatus;
 import com.synergy.backend.common.model.BaseEntity;
 import com.synergy.backend.member.model.entity.Member;
 import com.synergy.backend.product.model.entity.Product;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "cart")
 @Builder
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 public class Cart extends BaseEntity {
@@ -32,5 +36,22 @@ public class Cart extends BaseEntity {
 
     @Column(nullable = false)
     private Integer price;
+
+    public void increase() throws BaseException {
+        if (count <= 99) {
+            this.count += 1;
+        } else {
+            throw new BaseException(BaseResponseStatus.EXCEEDS_MAX_COUNT);
+        }
+    }
+
+    public void decrease() throws BaseException {
+        if (count > 1) {
+            this.count -= 1;
+        } else {
+            throw new BaseException(BaseResponseStatus.COUNT_BELOW_ZERO);
+        }
+    }
+
 
 }

--- a/backend/src/main/java/com/synergy/backend/orders/model/entity/OptionInCart.java
+++ b/backend/src/main/java/com/synergy/backend/orders/model/entity/OptionInCart.java
@@ -4,9 +4,15 @@ import com.synergy.backend.common.model.BaseEntity;
 import com.synergy.backend.product.model.entity.ProductMajorOptions;
 import com.synergy.backend.product.model.entity.ProductSubOptions;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "option_in_cart")
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class OptionInCart extends BaseEntity {
 
     @Id
@@ -24,6 +30,4 @@ public class OptionInCart extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "sub_option_idx")
     private ProductSubOptions subOption;
-
-    private Integer count;
 }

--- a/backend/src/main/java/com/synergy/backend/orders/model/request/AddCartOption.java
+++ b/backend/src/main/java/com/synergy/backend/orders/model/request/AddCartOption.java
@@ -1,8 +1,10 @@
 package com.synergy.backend.orders.model.request;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class AddCartOption {
     private Long majorOption;
     private Long subOption;

--- a/backend/src/main/java/com/synergy/backend/orders/model/request/AddCartOption.java
+++ b/backend/src/main/java/com/synergy/backend/orders/model/request/AddCartOption.java
@@ -1,0 +1,9 @@
+package com.synergy.backend.orders.model.request;
+
+import lombok.Getter;
+
+@Getter
+public class AddCartOption {
+    private Long majorOption;
+    private Long subOption;
+}

--- a/backend/src/main/java/com/synergy/backend/orders/model/request/AddCartReq.java
+++ b/backend/src/main/java/com/synergy/backend/orders/model/request/AddCartReq.java
@@ -3,12 +3,14 @@ package com.synergy.backend.orders.model.request;
 import com.synergy.backend.member.model.entity.Member;
 import com.synergy.backend.orders.model.entity.Cart;
 import com.synergy.backend.product.model.entity.Product;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
 @Getter
+@AllArgsConstructor
 public class AddCartReq {
 
     private Long productIdx;

--- a/backend/src/main/java/com/synergy/backend/orders/model/request/AddCartReq.java
+++ b/backend/src/main/java/com/synergy/backend/orders/model/request/AddCartReq.java
@@ -1,0 +1,34 @@
+package com.synergy.backend.orders.model.request;
+
+import com.synergy.backend.member.model.entity.Member;
+import com.synergy.backend.orders.model.entity.Cart;
+import com.synergy.backend.product.model.entity.Product;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class AddCartReq {
+
+    private Long productIdx;
+    private Long count;
+    private Integer price;
+    private List<AddCartOption> addCartOptions;
+
+    @Builder
+    public AddCartReq(Long productIdx, Long count, Integer price) {
+        this.productIdx = productIdx;
+        this.count = count;
+        this.price = price;
+    }
+
+    public Cart toEntity(Member member, Product product) {
+        return Cart.builder()
+                .member(member)
+                .product(product)
+                .price(this.price)
+                .count(this.count)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/orders/model/request/IncreaseProductReq.java
+++ b/backend/src/main/java/com/synergy/backend/orders/model/request/IncreaseProductReq.java
@@ -1,0 +1,9 @@
+package com.synergy.backend.orders.model.request;
+
+import lombok.Getter;
+
+@Getter
+public class IncreaseProductReq {
+
+    private Long cartIdx;
+}

--- a/backend/src/main/java/com/synergy/backend/orders/repository/CartRepository.java
+++ b/backend/src/main/java/com/synergy/backend/orders/repository/CartRepository.java
@@ -4,6 +4,4 @@ import com.synergy.backend.orders.model.entity.Cart;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
-
-
 }

--- a/backend/src/main/java/com/synergy/backend/orders/repository/CartRepository.java
+++ b/backend/src/main/java/com/synergy/backend/orders/repository/CartRepository.java
@@ -1,0 +1,9 @@
+package com.synergy.backend.orders.repository;
+
+import com.synergy.backend.orders.model.entity.Cart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+
+
+}

--- a/backend/src/main/java/com/synergy/backend/orders/repository/OptionInCartRepository.java
+++ b/backend/src/main/java/com/synergy/backend/orders/repository/OptionInCartRepository.java
@@ -1,0 +1,8 @@
+package com.synergy.backend.orders.repository;
+
+
+import com.synergy.backend.orders.model.entity.OptionInCart;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OptionInCartRepository extends JpaRepository<OptionInCart, Long> {
+}

--- a/backend/src/main/java/com/synergy/backend/orders/service/CartService.java
+++ b/backend/src/main/java/com/synergy/backend/orders/service/CartService.java
@@ -66,7 +66,21 @@ public class CartService {
                     .subOption(subOption)
                     .build());
         }
-
-
     }
+
+    @Transactional
+    public void increase(Long cartIdx) throws BaseException {
+        Cart cart = cartRepository.findById(cartIdx).orElseThrow(() ->
+                new BaseException(BaseResponseStatus.NOT_FOUND_CART));
+        cart.increase();
+    }
+
+    @Transactional
+    public void decrease(Long cartIdx) throws BaseException {
+        Cart cart = cartRepository.findById(cartIdx).orElseThrow(() ->
+                new BaseException(BaseResponseStatus.NOT_FOUND_CART));
+        cart.decrease();
+    }
+
+
 }

--- a/backend/src/main/java/com/synergy/backend/orders/service/CartService.java
+++ b/backend/src/main/java/com/synergy/backend/orders/service/CartService.java
@@ -1,0 +1,72 @@
+package com.synergy.backend.orders.service;
+
+import com.synergy.backend.common.BaseException;
+import com.synergy.backend.common.BaseResponseStatus;
+import com.synergy.backend.member.model.entity.Member;
+import com.synergy.backend.member.repository.MemberRepository;
+import com.synergy.backend.orders.model.entity.Cart;
+import com.synergy.backend.orders.model.entity.OptionInCart;
+import com.synergy.backend.orders.model.request.AddCartOption;
+import com.synergy.backend.orders.model.request.AddCartReq;
+import com.synergy.backend.orders.repository.CartRepository;
+import com.synergy.backend.orders.repository.OptionInCartRepository;
+import com.synergy.backend.product.model.entity.Product;
+import com.synergy.backend.product.model.entity.ProductMajorOptions;
+import com.synergy.backend.product.model.entity.ProductSubOptions;
+import com.synergy.backend.product.repository.ProductMajorOptionsRepository;
+import com.synergy.backend.product.repository.ProductRepository;
+import com.synergy.backend.product.repository.ProductSubOptionsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+    private final MemberRepository memberRepository;
+
+    private final CartRepository cartRepository;
+    private final OptionInCartRepository optionInCartRepository;
+
+    private final ProductRepository productRepository;
+    private final ProductMajorOptionsRepository majorOptionsRepository;
+    private final ProductSubOptionsRepository subOptionsRepository;
+
+
+    @Transactional
+    public void addCart(Long idx, AddCartReq req) throws BaseException {
+
+
+        Member member = memberRepository.findById(idx).orElseThrow(() ->
+                new BaseException(BaseResponseStatus.NOT_FOUND_USER));
+        Product product = productRepository.findById(req.getProductIdx()).orElseThrow(() ->
+                new BaseException(BaseResponseStatus.NOT_FOUND_PRODUCT));
+
+        //먼저 카트에 저장하고
+        Cart cart = cartRepository.save(req.toEntity(member, product));
+        //해당 상품의 옵션 저장, 옵션이 동일하면 수량 증가
+
+
+        for (AddCartOption option : req.getAddCartOptions()) {
+            ProductMajorOptions majorOption
+                    = majorOptionsRepository.findById(option.getMajorOption()).orElseThrow(() ->
+                    new BaseException(BaseResponseStatus.NOT_FOUND_PRODUCT_MAJOR_OPTIONS));
+
+            ProductSubOptions subOption
+                    = subOptionsRepository.findById(option.getSubOption()).orElseThrow(() ->
+                    new BaseException(BaseResponseStatus.NOT_FOUND_PRODUCT_SUB_OPTIONS));
+
+            optionInCartRepository.save(OptionInCart
+                    .builder()
+                    .cart(cart)
+                    .majorOption(majorOption)
+                    .subOption(subOption)
+                    .build());
+        }
+
+
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/product/model/entity/Product.java
+++ b/backend/src/main/java/com/synergy/backend/product/model/entity/Product.java
@@ -6,7 +6,6 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
 
 @Entity
 @Table(name = "product")

--- a/backend/src/main/java/com/synergy/backend/product/model/entity/Product.java
+++ b/backend/src/main/java/com/synergy/backend/product/model/entity/Product.java
@@ -3,9 +3,16 @@ package com.synergy.backend.product.model.entity;
 import com.synergy.backend.atelier.model.entity.Atelier;
 import com.synergy.backend.common.model.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 @Entity
 @Table(name = "product")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Product extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/com/synergy/backend/product/repository/ProductMajorOptionsRepository.java
+++ b/backend/src/main/java/com/synergy/backend/product/repository/ProductMajorOptionsRepository.java
@@ -1,0 +1,7 @@
+package com.synergy.backend.product.repository;
+
+import com.synergy.backend.product.model.entity.ProductMajorOptions;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductMajorOptionsRepository extends JpaRepository<ProductMajorOptions, Long> {
+}

--- a/backend/src/main/java/com/synergy/backend/product/repository/ProductRepository.java
+++ b/backend/src/main/java/com/synergy/backend/product/repository/ProductRepository.java
@@ -1,0 +1,7 @@
+package com.synergy.backend.product.repository;
+
+import com.synergy.backend.product.model.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/backend/src/main/java/com/synergy/backend/product/repository/ProductSubOptionsRepository.java
+++ b/backend/src/main/java/com/synergy/backend/product/repository/ProductSubOptionsRepository.java
@@ -1,0 +1,7 @@
+package com.synergy.backend.product.repository;
+
+import com.synergy.backend.product.model.entity.ProductSubOptions;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductSubOptionsRepository extends JpaRepository<ProductSubOptions, Long> {
+}


### PR DESCRIPTION
## 📚이슈 번호
#34 

## 📃요약
1. 장바구니 상품 추가
2. 수량 증가 및 감소


<br><br>

## 💪작업 상세 내용
**1. 장바구니 상품 추가기능**
상품 정보를 cart 테이블에 저장하고
리스트로 옵션을 받아와서 반복문을 돌며 모두 다 option_in_cart 테이블에 저장해줍니다.

**2. 장바구니 수량 증가**
상품의 수량은 엔티티 클래스에 직접 increase, decrease 메서드를 생성 후, 비즈니스 로직에선 @Transactional 어노테이션을 통해 더티체킹 해주는 방식을 채택했습니다.

**3. 동일 상품**
동일한 상품에서 같은 옵션을 담았을 때 수량만 증가하도록 하는 방법은 프론트에서 pinia를 통해 값을 저장하고, 이를 관리하는 방향으로 진행 예정입니다.
그러기 위해선 로그인 시 DB에 저장된 장바구니를 꺼내오는 작업이 필요할 것 같습니다. 

**5. 주문 페이지 데이터 관리**
장바구니에서 상품을 선택 후, 주문 페이지로 넘어갈 때 또한 DB에 저장하는 방식이 아니라 pinia에서 데이터를 임시로 저장하는 방식으로 진행할 예정입니다. 


<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->

<br><br>

## 💭참고 자료

<br><br>
