### PR TITLE
[Feat]해시태그 검색 기능 개발 (#85)

### DIFF
--- a/backend/src/main/java/com/synergy/backend/product/controller/ProductController.java
+++ b/backend/src/main/java/com/synergy/backend/product/controller/ProductController.java
@@ -19,4 +19,9 @@ public class ProductController {
         List<SearchProductRes> result = productService.search(categoryIdx);
         return ResponseEntity.ok(result);
     }
+    @GetMapping("/search/hashtag")
+    public ResponseEntity<List<SearchProductRes>> searchHashTag(Long hashtagIdx){
+        List<SearchProductRes> result = productService.searchHashTag(hashtagIdx);
+        return ResponseEntity.ok(result);
+    }
 }

--- a/backend/src/main/java/com/synergy/backend/product/model/entity/Product.java
+++ b/backend/src/main/java/com/synergy/backend/product/model/entity/Product.java
@@ -2,7 +2,10 @@ package com.synergy.backend.product.model.entity;
 
 import com.synergy.backend.atelier.model.entity.Atelier;
 import com.synergy.backend.common.model.BaseEntity;
+import com.synergy.backend.hashtag.model.entity.ProductHashtag;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
@@ -27,6 +30,9 @@ public class Product extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "category_idx")
     private Category category;
+
+    @OneToMany(mappedBy = "product")
+    List<ProductHashtag> productHashtagList = new ArrayList<>();
 
     private String name;
     private int price;

--- a/backend/src/main/java/com/synergy/backend/product/querydsl/ProductRepositoryCustom.java
+++ b/backend/src/main/java/com/synergy/backend/product/querydsl/ProductRepositoryCustom.java
@@ -5,4 +5,5 @@ import java.util.List;
 
 public interface ProductRepositoryCustom {
     List<Product> search(Long categoryIdx);
+    List<Product> searchHashTag(Long hashtagIdx);
 }

--- a/backend/src/main/java/com/synergy/backend/product/querydsl/ProductRepositoryCustomImpl.java
+++ b/backend/src/main/java/com/synergy/backend/product/querydsl/ProductRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.synergy.backend.product.querydsl;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.synergy.backend.hashtag.model.entity.QProductHashtag;
 import com.synergy.backend.product.model.entity.Product;
 import com.synergy.backend.product.model.entity.QCategory;
 import com.synergy.backend.product.model.entity.QProduct;
@@ -15,11 +16,13 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom{
     private final JPAQueryFactory queryFactory;
     private QProduct product;
     private QCategory category;
+    private QProductHashtag productHashtag;
 
     public ProductRepositoryCustomImpl(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
         this.product = QProduct.product;
         this.category = QCategory.category;
+        this.productHashtag = QProductHashtag.productHashtag;
     }
 
     @Override
@@ -32,6 +35,16 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom{
                 .fetch();
     }
 
+    @Override
+    public List<Product> searchHashTag(Long hashtagIdx) {
+        return queryFactory
+                .selectFrom(product)
+//                .leftJoin(productHashtag.product, product).fetchJoin()
+                .leftJoin(productHashtag).on(productHashtag.product.eq(product))
+                .where(hashTagEq(hashtagIdx))
+                .fetch();
+    }
+
     private BooleanExpression categoryEq(Long categoryIdx){
         if(categoryIdx==null){
             return null;
@@ -39,6 +52,13 @@ public class ProductRepositoryCustomImpl implements ProductRepositoryCustom{
 
         List<Long> categoryIds = findAllSubCategoryIds(categoryIdx);
         return product.category.idx.in(categoryIds);
+    }
+    private BooleanExpression hashTagEq(Long hashtagIdx){
+        if(hashtagIdx==null){
+            return null;
+        }
+
+        return productHashtag.hashtag.idx.eq(hashtagIdx);
     }
 
     private List<Long> findAllSubCategoryIds(Long parentCategoryIdx) {

--- a/backend/src/main/java/com/synergy/backend/product/service/ProductService.java
+++ b/backend/src/main/java/com/synergy/backend/product/service/ProductService.java
@@ -31,4 +31,23 @@ public class ProductService {
 
         return response;
     }
+
+    public List<SearchProductRes> searchHashTag(Long hashtagIdx) {
+        List<Product> result = productRepository.searchHashTag(hashtagIdx);
+
+        List<SearchProductRes> response = new ArrayList<>();
+
+        for (Product product : result) {
+            response.add(SearchProductRes.builder()
+                    .idx(product.getIdx())
+                    .name(product.getName())
+                    .price(product.getPrice())
+                    .averageScore(product.getAverageScore())
+//                    .atelier_name(product.getAtelier().getName())
+                    .category_name(product.getCategory().getCategoryName())
+                    .thumbnailUrl(product.getThumbnailUrl())
+                    .build());
+        }
+        return response;
+    }
 }


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->
#85 

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->
- 해시태그 검색 기능
- 해시태그 idx에 대해 검색을 하면 해당 해시태그와 관련된 상품을 검색 조회

<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->
- ```searchHashTag``` 메서드가 해시태그 검색 메서드입니다.
- 해시태그 검색을 hashtag 패키지에 넣을지, product 패키지에 넣을지 고민했는데 결국 조회 결과는 product에 대한 dto이기 때문에 product 패키지에 구현했습니다.

#### 트러블슈팅
초기 코드 :  ```leftJoin(productHashtag.product, product).fetchJoin()```
에러 메세지 : Could not resolve join path 'productHashtag.product'
해결 코드 :  ```leftJoin(productHashtag).on(productHashtag.product.eq(product))```
<원인>
QueryDSL이 조인 경로를 정확하게 해석할 수 있도록 명시적으로 on() 절을 사용해 두 엔티티 간의 관계를 정의해줘야함

하지만 이부분에 대해서는 좀더 공부가 필요할 것 같습니다
<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->
- toEntity를 service에 작성해서 추후 dto로 옮기는 작업을 할 예정입니다.

<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
