### PR TITLE
[Feat]상품 캐러셀 구현(#98)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,8 @@
         "pinia": "^2.2.2",
         "pinia-plugin-persistedstate": "^4.0.0",
         "vue": "^3.2.13",
-        "vue-router": "^4.4.3"
+        "vue-router": "^4.4.3",
+        "vue3-carousel": "^0.3.3"
       },
       "devDependencies": {
         "@babel/core": "^7.12.16",
@@ -11838,6 +11839,15 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "node_modules/vue3-carousel": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/vue3-carousel/-/vue3-carousel-0.3.3.tgz",
+      "integrity": "sha512-VsuOBE4LG9lxAiYGR9U7ps4RyJ4oFQGzk79/49ybvoxzNpahPAVWIDHKK3a1lOv0CSplFq6u4FvaFLZ8x3FgWg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "vue": "^3.2.0"
+      }
     },
     "node_modules/watchpack": {
       "version": "2.4.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "pinia": "^2.2.2",
     "pinia-plugin-persistedstate": "^4.0.0",
     "vue": "^3.2.13",
-    "vue-router": "^4.4.3"
+    "vue-router": "^4.4.3",
+    "vue3-carousel": "^0.3.3"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",

--- a/frontend/src/components/product/ProductCarouselComponent.vue
+++ b/frontend/src/components/product/ProductCarouselComponent.vue
@@ -1,0 +1,67 @@
+<template>
+  <Carousel>
+    <Slide v-for="slide in 2" :key="slide">
+      <div class="carousel__item"><ProductListComponent :productList="this.productStore.productList" :layout="5"/></div>
+    </Slide>
+
+    <template #addons>
+      <Navigation />
+      <Pagination />
+    </template>
+  </Carousel>
+</template>
+
+<script>
+import { defineComponent } from 'vue'
+import { Carousel, Navigation, Pagination, Slide } from 'vue3-carousel'
+import 'vue3-carousel/dist/carousel.css'
+import ProductListComponent from './ProductListComponent.vue'
+import { mapStores } from "pinia";
+import { useProductStore } from "@/stores/useProductStore"
+
+export default defineComponent({
+    name: 'ProductCarousel',
+    computed: {
+        ...mapStores(useProductStore)
+    },
+    components: {
+        Carousel,
+        Slide,
+        Pagination,
+        Navigation,
+        ProductListComponent
+    },
+    created(){
+        this.searchByCategory()
+    },
+    methods:{
+        searchByCategory(){
+            this.productStore.searchByCategory();
+        }
+    }
+})
+</script>
+
+<style scoped>
+.carousel__item {
+  min-height: 200px;
+  width: 100%;
+  /* background-color: var(--vc-clr-primary); */
+  color: var(--vc-clr-white);
+  font-size: 20px;
+  border-radius: 8px;
+  /* display: flex; */
+  justify-content: center;
+  align-items: center;
+}
+
+.carousel__slide {
+  padding: 10px 70px;
+}
+
+.carousel__prev,
+.carousel__next {
+  box-sizing: content-box;
+  border: 5px solid white;
+}
+</style>

--- a/frontend/src/components/product/ProductListComponent.vue
+++ b/frontend/src/components/product/ProductListComponent.vue
@@ -1,33 +1,30 @@
 <template>
-<div class="product-list-container">
-    <ProductComponentVue v-for="product in this.productStore.productList" :key="product.idx" :product="product"/>
+<div class="product-list-container" :class="layoutClass">
+    <ProductComponentVue v-for="product in productList" :key="product.idx" :product="product"/>
 </div>
-<!-- <button @click="searchByCategory">요청</button> -->
   
 </template>
 
 <script>
-import { mapStores } from "pinia";
-import { useProductStore } from "@/stores/useProductStore"
 import ProductComponentVue from './ProductComponent.vue'
 
 export default {
-    computed: {
-        ...mapStores(useProductStore)
-    },
     components:{
         ProductComponentVue
     },
-    created(){
-        this.searchByCategory()
-    },
-    data() {
-        return {
+    props:{
+        productList: {
+            type: Object,
+            required: true
+        },
+        layout:{
+            type : Number,
+            required: true
         }
     },
-    methods:{
-        searchByCategory(){
-            this.productStore.searchByCategory();
+    computed:{
+        layoutClass() {
+            return this.layout === 4 ? 'layout-4' : 'layout-5';
         }
     }
 }
@@ -37,8 +34,13 @@ export default {
 .product-list-container{
     padding: 10px;
     display: grid;
-    grid-template-columns: auto auto auto auto;
     gap: 10px;
+}
+.layout-4{
+    grid-template-columns: auto auto auto auto;
+}
+.layout-5{
+    grid-template-columns: auto auto auto auto auto;
 }
 
 </style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,6 +3,7 @@ import App from "@/App";
 // import ProductComponent from "@/components/product/ProductComponent"
 import ProductListComponent from "@/components/product/ProductListComponent"
 import DeliveryComponent from '@/components/member/DeliveryComponent.vue';
+import Carousel from '@/components/product/ProductCarouselComponent';
 
 const router = createRouter({
     history: createWebHistory(),
@@ -26,6 +27,10 @@ const router = createRouter({
             path: '/deliveryAddress',
             component: DeliveryComponent,
         },
+        {
+            path: '/carousel',
+            component: Carousel
+        }
     ],
 });
 


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->
#98 

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->
-상품 리스트 컴포넌트 개발

<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->
- 기존 상품 리스트 컴포넌트는 prosuctStore에서 바로 데이터로 가져오기 때문에 종류가 다른 상품 리스트에는 공용으로 사용할 수 없었습니다.
- 상품 리스트 컴포넌트에 props로 productList를 전달해주는 방식으로 변경해 다양한 상품리스트에 사용할 수 있게 됐습니다.
- 일반 상품 리스트 페이지는 layout이 4column로 구성돼있지만 메인 페이지의 캐러셀에 있는 상품 리스트는 layout이 5column인 점에 따라 상품 리스트 컴포넌트에 layout props를 추가했습니다.
- props 전달 모습은 아래 코드와 같습니다.
```<ProductListComponent :productList="listYouWant" :layout="5"/>```

layout = 5일 때
<img width="894" alt="스크린샷 2024-09-10 오후 3 02 31" src="https://github.com/user-attachments/assets/8e6aa907-ee38-42f4-b2cb-639e070281df">
layout = 4일 때
<img width="893" alt="스크린샷 2024-09-10 오후 3 02 49" src="https://github.com/user-attachments/assets/eec8d303-5e74-47ed-93db-1976c3a125eb">


<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->
- 첫번째 슬라이드에는 page 0, size 10, 두번째 슬라이드에는 page 1, size 10에 대한 리스틀 뿌려야 하는데, 아직 밴엔드쪽에 페이징 처리가 완료돼지 않아서 추후 백엔드에서 페이징 처리 후에 개선할 예정입니다 .
- 현재는 슬라이드가 끝이나면 다음 슬라이드로 넘기지 못힘
- 실제 사이트에서는 슬라이드가 끝나도 다음 페이지 누르면 첫번째 슬라이드가 나오는 방식(무한 넘김)
- 이 부분은 우선순위 업무 끝낸 후에 개선 예정

<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
