### PR TITLE
[Feat] 회원 정보 조회 기능 추가

### DIFF
--- a/backend/src/main/java/com/synergy/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.synergy.backend.domain.member.controller;
 
 
+import com.synergy.backend.domain.member.model.response.MemberInfoRes;
 import com.synergy.backend.global.exception.BaseException;
 import com.synergy.backend.global.common.BaseResponse;
 import com.synergy.backend.global.common.BaseResponseStatus;
@@ -8,8 +9,10 @@ import com.synergy.backend.domain.member.service.MemberService;
 import com.synergy.backend.domain.member.model.request.CreateDeliveryAddressReq;
 import com.synergy.backend.domain.member.model.request.MemberSignupReq;
 import com.synergy.backend.domain.member.model.response.DeliveryAddressRes;
+import com.synergy.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -51,5 +54,14 @@ public class MemberController {
         Long userIdx = 1L;
         memberService.createDeliveryAddress(req, userIdx);
         return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+    }
+
+    @GetMapping("/login")
+    public BaseResponse<MemberInfoRes> getMemberInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails)
+            throws BaseException {
+        Long memberIdx = customUserDetails.getIdx();
+        MemberInfoRes memberInfo = memberService.getMemberInfo(memberIdx);
+
+        return new BaseResponse<>(memberInfo);
     }
 }

--- a/backend/src/main/java/com/synergy/backend/domain/member/model/response/MemberInfoRes.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/model/response/MemberInfoRes.java
@@ -1,0 +1,39 @@
+package com.synergy.backend.domain.member.model.response;
+
+import com.synergy.backend.domain.member.model.entity.Member;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberInfoRes {
+
+    private Long idx;
+    private String nickname;
+    private String email;
+    private String cellphone;
+    private LocalDate birthday;
+    private String profileImageUrl;
+
+    @Builder
+    public MemberInfoRes(Long idx, String nickname, String email, String cellphone, LocalDate birthday,
+                         String profileImageUrl) {
+        this.idx = idx;
+        this.nickname = nickname;
+        this.email = email;
+        this.cellphone = cellphone;
+        this.birthday = birthday;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public static MemberInfoRes from(Member member) {
+        return MemberInfoRes.builder()
+                .idx(member.getIdx())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .cellphone(member.getCellPhone())
+                .birthday(member.getBirthday())
+                .profileImageUrl(member.getProfileImageUrl())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.synergy.backend.domain.member.service;
 
+import com.synergy.backend.domain.member.model.response.MemberInfoRes;
 import com.synergy.backend.global.exception.BaseException;
 import com.synergy.backend.global.common.BaseResponseStatus;
 import com.synergy.backend.domain.member.model.entity.DeliveryAddress;
@@ -89,5 +90,14 @@ public class MemberService {
     private Member getMember(Long userIdx) throws BaseException {
         return memberRepository.findById(userIdx).orElseThrow(() ->
                 new BaseException(BaseResponseStatus.NOT_FOUND_USER));
+    }
+
+    public MemberInfoRes getMemberInfo(Long idx) throws BaseException {
+        Member member = memberRepository.findById(idx).orElseThrow(() ->
+                new BaseException(BaseResponseStatus.NOT_FOUND_USER));
+
+        MemberInfoRes memberInfoRes = MemberInfoRes.from(member);
+
+        return memberInfoRes;
     }
 }


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->
#12 

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->

- 로그인이 성공시 , 클라이언트측에서 회원정보를 조회하여 사용할 수 있게끔 api 를 구현하였습니다.

<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->

조회하여 사용할 수 있는 데이터 내역들은 아래와 같습니다.

![image](https://github.com/user-attachments/assets/a4e0077e-6f4d-4a2f-8bb5-2e226423d0c8)

<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->

현재 프로필 이미지 같은 경우는 정보에 담기지 않아 null 로 고정이 되겠으나, 
추후 기능 구현하면 프로필 이미지도 담아서 조회가 가능할 것 입니다.

<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
