### PR TITLE
[Feat] 회원정보 수정 기능 구현 

### DIFF
--- a/backend/src/main/java/com/synergy/backend/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.synergy.backend.domain.member.controller;
 
 
+import com.synergy.backend.domain.member.model.request.MemberUpdateReq;
 import com.synergy.backend.domain.member.model.response.MemberInfoRes;
 import com.synergy.backend.global.exception.BaseException;
 import com.synergy.backend.global.common.BaseResponse;
@@ -63,5 +64,14 @@ public class MemberController {
         MemberInfoRes memberInfo = memberService.getMemberInfo(memberIdx);
 
         return new BaseResponse<>(memberInfo);
+    }
+
+    @PutMapping("/info")
+    public BaseResponse<MemberInfoRes> updateMemberInfo(@RequestBody MemberUpdateReq req, @AuthenticationPrincipal CustomUserDetails customUserDetails)
+            throws BaseException {
+        System.out.println(req.getNickname());
+        Long memberIdx = customUserDetails.getIdx();
+        return new BaseResponse<>(memberService.updateMemberInfo(memberIdx, req));
+
     }
 }

--- a/backend/src/main/java/com/synergy/backend/domain/member/model/entity/Member.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/model/entity/Member.java
@@ -1,5 +1,6 @@
 package com.synergy.backend.domain.member.model.entity;
 
+import com.synergy.backend.domain.member.model.request.MemberUpdateReq;
 import com.synergy.backend.global.common.model.BaseEntity;
 import jakarta.persistence.*;
 import java.time.LocalDate;
@@ -61,6 +62,10 @@ public class Member extends BaseEntity {
         this.idx = idx;
         this.email = username;
         this.role = role;
+    }
+
+    public void changeMemberInfo(MemberUpdateReq req){
+        this.nickname = req.getNickname();
     }
   
     public void updateDefaultAddress(DeliveryAddress deliveryAddress) {

--- a/backend/src/main/java/com/synergy/backend/domain/member/model/request/MemberUpdateReq.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/model/request/MemberUpdateReq.java
@@ -1,0 +1,8 @@
+package com.synergy.backend.domain.member.model.request;
+
+import lombok.Getter;
+
+@Getter
+public class MemberUpdateReq {
+    private String nickname;
+}

--- a/backend/src/main/java/com/synergy/backend/domain/member/service/MemberService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.synergy.backend.domain.member.service;
 
+import com.synergy.backend.domain.member.model.request.MemberUpdateReq;
 import com.synergy.backend.domain.member.model.response.MemberInfoRes;
 import com.synergy.backend.global.exception.BaseException;
 import com.synergy.backend.global.common.BaseResponseStatus;
@@ -97,6 +98,17 @@ public class MemberService {
                 new BaseException(BaseResponseStatus.NOT_FOUND_USER));
 
         MemberInfoRes memberInfoRes = MemberInfoRes.from(member);
+
+        return memberInfoRes;
+    }
+
+    public MemberInfoRes updateMemberInfo(Long memberIdx, MemberUpdateReq req) throws BaseException {
+        Member member = getMember(memberIdx);
+        member.changeMemberInfo(req);
+
+        Member newMember = memberRepository.save(member);
+
+        MemberInfoRes memberInfoRes = MemberInfoRes.from(newMember);
 
         return memberInfoRes;
     }


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->
#6 

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->

- 회원 정보 수정 기능 구현
- 수정 페이지에서는 닉네임만 변경 가능하도록 설정 (추후 추가 가능)

<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->

<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->

현재는 단편적으로 닉네임만 수정 가능하도록 설정하였으나, 추후 전화번호, 이메일 수신여부 등의 내용들도 추가로 함께 매개변수로 받아서 추가할 수 있도록 코드를 작성하였습니다. 

이메일은 해당 페이지에서 [수정하기] 버튼을 눌러서 수정이 가능하게 하지 않았습니다. 
-> 이는 이메일 변경 같은 경우는 따로 이메일 인증을 추가로 받아서 해당 메일로 변경 확정 시키도록 설정 할 예정입니다.

![image](https://github.com/user-attachments/assets/183393e9-5e89-410b-b9bd-f786ffef3033)


<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
