### PR TITLE
[Feat] 내 등급 조회, 전체 등급 조회 기능 

### DIFF
--- a/backend/src/main/java/com/synergy/backend/domain/member/controller/GradeController.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/controller/GradeController.java
@@ -1,0 +1,39 @@
+package com.synergy.backend.domain.member.controller;
+
+import com.synergy.backend.domain.member.model.response.GetMyGradeRes;
+import com.synergy.backend.domain.member.model.response.GradeRes;
+import com.synergy.backend.domain.member.service.GradeService;
+import com.synergy.backend.global.common.BaseResponse;
+import com.synergy.backend.global.exception.BaseException;
+import com.synergy.backend.global.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/mypage/grade")
+@RequiredArgsConstructor
+public class GradeController {
+
+    private final GradeService gradeService;
+
+    //내 등급 조회
+    @GetMapping("/me")
+    public BaseResponse<GetMyGradeRes> getMyGrade(@AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
+        GetMyGradeRes myGrade = gradeService.getMyGrade(customUserDetails.getIdx());
+        return new BaseResponse<>(myGrade);
+    }
+
+
+    //모든 등급 조회
+    @GetMapping("/info")
+    public BaseResponse<List<GradeRes>> getAllGrade() {
+        return new BaseResponse<>(gradeService.getAllGrade());
+    }
+
+
+}

--- a/backend/src/main/java/com/synergy/backend/domain/member/model/entity/Grade.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/model/entity/Grade.java
@@ -2,9 +2,11 @@ package com.synergy.backend.domain.member.model.entity;
 
 import com.synergy.backend.global.common.model.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
 @Table(name = "grade")
+@Getter
 public class Grade extends BaseEntity {
 
     @Id

--- a/backend/src/main/java/com/synergy/backend/domain/member/model/response/GetMyGradeRes.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/model/response/GetMyGradeRes.java
@@ -1,0 +1,27 @@
+package com.synergy.backend.domain.member.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class GetMyGradeRes {
+
+    private String myGrade;
+    private String expectedGrade;
+    private String amountToNext;
+    private String benefitMessage;
+    private List<GradeRes> allGrades;
+
+    public static GetMyGradeRes from(String myGrade, String expectedGrade, String amountToNext, List<GradeRes> allGrades, String benefitMessage) {
+        return GetMyGradeRes.builder()
+                .myGrade(myGrade)
+                .expectedGrade(expectedGrade)
+                .amountToNext(amountToNext)
+                .allGrades(allGrades)
+                .benefitMessage(benefitMessage)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/domain/member/model/response/GradeRes.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/model/response/GradeRes.java
@@ -1,0 +1,42 @@
+package com.synergy.backend.domain.member.model.response;
+
+import com.synergy.backend.domain.member.model.entity.Grade;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GradeRes {
+
+    private Long gradeIdx;
+    private String name;
+    private Integer conditionMax;
+    private Integer conditionMin;
+    private Integer defaultPercent;
+
+    private Integer recurPercent;
+    private Integer recurNum;
+
+    private Integer upgradePercent;
+    private Integer upgradeNum;
+
+    private String imageUrl;
+
+
+    public static GradeRes from(Grade grade) {
+        return GradeRes
+                .builder()
+                .gradeIdx(grade.getIdx())
+                .name(grade.getName())
+                .conditionMax(grade.getConditionMax())
+                .conditionMin(grade.getConditionMin())
+                .defaultPercent(grade.getDefaultPercent())
+                .recurPercent(grade.getRecurPercent())
+                .recurNum(grade.getRecurNum())
+                .upgradePercent(grade.getUpgradePercent())
+                .upgradeNum(grade.getUpgradeNum())
+                .imageUrl(grade.getImageUrl())
+                .build();
+    }
+
+}

--- a/backend/src/main/java/com/synergy/backend/domain/member/repository/GradeRepository.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/repository/GradeRepository.java
@@ -1,0 +1,7 @@
+package com.synergy.backend.domain.member.repository;
+
+import com.synergy.backend.domain.member.model.entity.Grade;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GradeRepository extends JpaRepository<Grade, Long> {
+}

--- a/backend/src/main/java/com/synergy/backend/domain/member/service/GradeService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/service/GradeService.java
@@ -1,0 +1,110 @@
+package com.synergy.backend.domain.member.service;
+
+import com.synergy.backend.domain.member.model.entity.Grade;
+import com.synergy.backend.domain.member.model.entity.Member;
+import com.synergy.backend.domain.member.model.response.GetMyGradeRes;
+import com.synergy.backend.domain.member.model.response.GradeRes;
+import com.synergy.backend.domain.member.repository.GradeRepository;
+import com.synergy.backend.domain.member.repository.MemberRepository;
+import com.synergy.backend.domain.orders.repository.OrderRepository;
+import com.synergy.backend.global.common.BaseResponseStatus;
+import com.synergy.backend.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.text.NumberFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GradeService {
+
+    private final GradeRepository gradeRepository;
+    private final OrderRepository orderRepository;
+    private final MemberRepository memberRepository;
+
+    public List<GradeRes> getAllGrade() {
+        return gradeRepository.findAll().stream().map(grade ->
+                GradeRes.from(grade)
+        ).collect(Collectors.toList());
+    }
+
+    public GetMyGradeRes getMyGrade(Long idx) throws BaseException {
+        Member member = memberRepository.findById(idx).orElseThrow(() ->
+                new BaseException(BaseResponseStatus.NOT_FOUND_USER));
+
+        LocalDate now = LocalDate.now();
+
+        LocalDateTime startDateTime = now.minusMonths(6).withDayOfMonth(1).atStartOfDay();
+        LocalDateTime endDateTime = now.withDayOfMonth(now.lengthOfMonth()).atTime(23, 59, 59);
+        Integer totalAmount = orderRepository.findTotalAmountByMemberIdAndDateRange(idx, startDateTime, endDateTime);
+
+        Grade curGrade = member.getGrade();
+        String curGradeName = curGrade.getName();
+        Long curGradeIdx = curGrade.getIdx();
+
+        // 전체 등급 조회
+        List<GradeRes> allGrades = getAllGrade();
+        String expectedGrade = null;
+        String benefitsMessage = null;
+        String amountToNext = null;
+
+        for (int i = 0; i < allGrades.size(); i++) {
+            GradeRes grade = allGrades.get(i);
+            if (totalAmount >= grade.getConditionMin() &&
+                    totalAmount < grade.getConditionMax()) {
+
+                expectedGrade = grade.getName();
+                Long expectedGradeIdx = grade.getGradeIdx();
+
+                if (curGradeIdx.equals(expectedGradeIdx)) {
+
+                    // 현재 등급과 예상 등급이 같은 경우
+                    if (i + 1 < allGrades.size()) {
+
+                        // 다음 등급이 존재하는 경우
+                        amountToNext = formatCurrency(Math.max(0, allGrades.get(i + 1).getConditionMin() - totalAmount));
+                        benefitsMessage = amountToNext + "원만 더 구매하면 다음 달 " + allGrades.get(i + 1).getName() + " 혜택을 받을 수 있습니다.";
+                    } else {
+
+                        // 마지막 등급인 경우
+                        amountToNext = "0원";
+                        benefitsMessage = "현재 등급은 " + expectedGrade + "입니다! ";
+                    }
+                } else if (curGradeIdx < expectedGradeIdx) {
+
+                    // 예상 등급이 현재 등급보다 높은 경우
+                    amountToNext = formatCurrency(Math.max(0, grade.getConditionMin() - totalAmount));
+                    benefitsMessage = "다음 달 " + expectedGrade + " 혜택을 받을 수 있습니다.";
+                } else {
+
+                    // 예상 등급이 현재 등급보다 낮은 경우
+                    amountToNext = "승급 불가능";
+                    benefitsMessage = "다음 달 예상 등급은 " + expectedGrade + "입니다.";
+                }
+
+                break;
+            }
+        }
+
+        // 예상 등급이 없으면 현재 등급을 예상 등급으로
+        if (expectedGrade == null) {
+            expectedGrade = curGradeName;
+            amountToNext = "0원";
+            benefitsMessage = "현재 등급은 " + curGradeName + "입니다.";
+        }
+
+        return GetMyGradeRes.from(curGradeName, expectedGrade, amountToNext, allGrades, benefitsMessage);
+    }
+
+
+    public String formatCurrency(Integer amount) {
+        NumberFormat formatter = NumberFormat.getInstance(new Locale("ko", "KR"));
+        return formatter.format(amount);
+    }
+}
+

--- a/backend/src/main/java/com/synergy/backend/domain/orders/repository/OrderRepository.java
+++ b/backend/src/main/java/com/synergy/backend/domain/orders/repository/OrderRepository.java
@@ -1,16 +1,30 @@
 package com.synergy.backend.domain.orders.repository;
 
 import com.synergy.backend.domain.orders.model.entity.Orders;
-import com.synergy.backend.domain.orders.model.entity.Present;
 import com.synergy.backend.domain.orders.querydsl.OrderRepositoryCustom;
-import com.synergy.backend.domain.orders.querydsl.OrderRepositoryCustomImpl;
-import java.util.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface OrderRepository extends JpaRepository<Orders, Long> , OrderRepositoryCustom {
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface OrderRepository extends JpaRepository<Orders, Long>, OrderRepositoryCustom {
     List<Orders> findAllByPresentIdx(Long idx);
+
     @Query("SELECT o FROM Orders o JOIN FETCH o.product JOIN FETCH o.product.atelier WHERE o.present.idx = :idx")
     List<Orders> findAllByPresentIdxWithProductAndAtelier(Long idx);
 
+
+    @Query("SELECT SUM(o.totalPrice) FROM Orders o " +
+            "WHERE o.member.idx = :memberIdx " +
+            "AND o.paymentState = '결제완료' " +
+            "AND o.deliveryState = '배송완료' " +
+            "AND o.modifiedAt BETWEEN :startDate AND :endDate")
+    Integer findTotalAmountByMemberIdAndDateRange(
+            @Param("memberIdx") Long memberIdx,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate
+    );
 }


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->
#40 

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->
등급 전체 조회 api
내 등급 조회 api

<br><br>

## 💪작업 상세 내용
**1. 전체 등급 조회 api**
내 등급 조회 api에서도 전체 등급을 리스트로 반환해주긴 하지만 필요한 곳이 있을 수 있으니 만들어놨습니다.
ex) 등급 정보 확인란 등 

**2. 내 등급 조회 api**
내 등급을 조회하면 아래의 정보를 반환해줍니다.
```
    private String myGrade; // 등급 이름 
    private String expectedGrade; // 다음달 예상 등급
    private String amountToNext; // 등급 업까지 남은 금액
    private String benefitMessage; // expectedGrade에 따른 메세지
    private List<GradeRes> allGrades; //전체 등급 
```
내 주문목록을 조회하여 최근 6개월동안의 총 결제금액을 파악합니다.

결제금액이 어느 등급에 해당하는지 판단하기 위해 반복문을 돌며

1. 현재 등급과 예상 등급이 같은 경우
    - 다음 등급이 존재하는 경우
    - 마지막 등급인 경우
 2. 예상 등급이 현재 등급보다 높은 경우
 3. 예상 등급이 현재 등급보다 낮은 경우

위 경우를 구분하여 판단하고 해당하는 메세지를 benefitMessage에 담아 보내주게 됩니다.
amountToNext을 String 타입으로 한 이유는 미리 포맷팅 한 후에 같이 보내주는 게 낫다고 생각했기 때문인데 Integer로 변경해도 괜찮을 것 같습니다. 



<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->

<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
