### PR TITLE
Backend/feature/coupon

### DIFF
--- a/backend/src/main/java/com/synergy/backend/domain/coupon/controller/CouponController.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/controller/CouponController.java
@@ -1,0 +1,27 @@
+package com.synergy.backend.domain.coupon.controller;
+
+import com.synergy.backend.domain.coupon.scheduler.CouponScheduler;
+import com.synergy.backend.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mypage/coupon")
+public class CouponController {
+
+    private final CouponScheduler couponScheduler;
+
+    //내 쿠폰 조회, 페이징 처리
+
+    //쿠폰 발급 스케줄러 테스트용
+    @GetMapping("/test")
+    public String coupon() throws BaseException {
+        couponScheduler.issuedCoupon();
+        return "성공";
+    }
+
+
+}

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/model/entity/Coupon.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/model/entity/Coupon.java
@@ -1,8 +1,12 @@
 package com.synergy.backend.domain.coupon.model.entity;
 
+import com.synergy.backend.domain.coupon.model.type.CouponType;
+import com.synergy.backend.domain.grade.model.entity.Grade;
 import com.synergy.backend.global.common.model.BaseEntity;
-import com.synergy.backend.domain.member.model.entity.Member;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
@@ -13,16 +17,14 @@ public class Coupon extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
 
-    @ManyToOne
-    @JoinColumn(name = "member_idx")
-    private Member member;
-
     private String name;
-    private String type;
+    @Enumerated(EnumType.STRING)
+    private CouponType type;
+
     private String code;
     private Integer discountPercent;
-    private LocalDateTime publicationDate;
-    private LocalDateTime expiration;
-    private String minimumOrderPrice;
-    private String maximumDiscountPrice;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "grade_idx")
+    private Grade grade;
 }

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/model/entity/MemberCoupon.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/model/entity/MemberCoupon.java
@@ -1,0 +1,32 @@
+package com.synergy.backend.domain.coupon.model.entity;
+
+import com.synergy.backend.domain.member.model.entity.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberCoupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long idx;
+
+    private LocalDateTime publicationDate;
+    private LocalDateTime expirationDate;
+
+    @ManyToOne
+    @JoinColumn(name = "coupon_idx")
+    private Coupon coupon;
+
+    @ManyToOne
+    @JoinColumn(name = "member_idx")
+    private Member member;
+
+}

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/model/type/CouponType.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/model/type/CouponType.java
@@ -1,0 +1,9 @@
+package com.synergy.backend.domain.coupon.model.type;
+
+public enum CouponType {
+    WELCOME, //웰컴 쿠폰
+    RECUR, // 정기 쿠폰
+    UPGRADE, // 승급 쿠폰
+
+
+}

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/repository/CouponRepository.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/repository/CouponRepository.java
@@ -1,0 +1,16 @@
+package com.synergy.backend.domain.coupon.repository;
+
+
+import com.synergy.backend.domain.coupon.model.entity.Coupon;
+import com.synergy.backend.domain.coupon.model.type.CouponType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+    @Query("SELECT c FROM Coupon c WHERE c.grade.idx = :gradeId AND c.type = :type")
+    Coupon findCouponsByGradeWithRecur(@Param("gradeId") Long gradeId, @Param("type") CouponType type);
+}

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/repository/MemberCouponRepository.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/repository/MemberCouponRepository.java
@@ -1,0 +1,8 @@
+package com.synergy.backend.domain.coupon.repository;
+
+import com.synergy.backend.domain.coupon.model.entity.MemberCoupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberCouponRepository extends JpaRepository<MemberCoupon, Long> {
+
+}

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/scheduler/CouponScheduler.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/scheduler/CouponScheduler.java
@@ -1,0 +1,61 @@
+package com.synergy.backend.domain.coupon.scheduler;
+
+import com.synergy.backend.domain.coupon.model.entity.Coupon;
+import com.synergy.backend.domain.coupon.repository.CouponRepository;
+import com.synergy.backend.domain.coupon.service.FetchCouponWithGradeService;
+import com.synergy.backend.domain.coupon.service.MemberCouponService;
+import com.synergy.backend.domain.grade.model.entity.Grade;
+import com.synergy.backend.domain.grade.service.FetchGradeService;
+import com.synergy.backend.domain.grade.service.FetchMemberService;
+import com.synergy.backend.domain.member.model.entity.Member;
+import com.synergy.backend.global.exception.BaseException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+public class CouponScheduler {
+
+    private final FetchMemberService fetchMemberService;
+    private final FetchGradeService fetchGradeService;
+    private final FetchCouponWithGradeService fetchCouponWithGradeService;
+    private final MemberCouponService memberCouponService;
+
+    public CouponScheduler(@Qualifier("fetchMemberByGradeServiceImpl") FetchMemberService fetchMemberService,
+                           FetchGradeService fetchGradeService, CouponRepository couponRepository, FetchCouponWithGradeService fetchCouponWithGradeService, MemberCouponService memberCouponService) {
+        this.fetchMemberService = fetchMemberService;
+        this.fetchGradeService = fetchGradeService;
+        this.fetchCouponWithGradeService = fetchCouponWithGradeService;
+        this.memberCouponService = memberCouponService;
+    }
+
+
+    //    @Scheduled(cron = "0 0 0 1 * ?")
+    public void issuedCoupon() throws BaseException {
+                /*
+        1. 전체 등급 조회
+        2. 등급에 맞는 쿠폰 조회
+        3. 등급에 해당하는 유저 리스트 조회
+        4. 유저에게 쿠폰 발행
+         */
+        LocalDate now = LocalDate.now();
+        LocalDateTime publicationDate = now.atStartOfDay();
+        LocalDateTime expirationDate = now.plusMonths(1).atStartOfDay();
+
+        List<Grade> grades = fetchGradeService.getGrade();
+        for (Grade grade : grades) {
+            Integer recurNum = grade.getRecurNum();
+            Coupon coupon = fetchCouponWithGradeService.findByGradeWithRecur(grade.getIdx());
+            List<Member> members = fetchMemberService.FetchMember(grade.getIdx());
+
+            for (Member member : members) {
+                for (int i = 0; i < recurNum; i++) {
+                    memberCouponService.publish(publicationDate, expirationDate, member, coupon);
+                }
+            }
+        }
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/service/CouponService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/service/CouponService.java
@@ -1,0 +1,11 @@
+package com.synergy.backend.domain.coupon.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CouponService {
+
+
+}

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/service/FetchCouponWithGradeService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/service/FetchCouponWithGradeService.java
@@ -1,0 +1,19 @@
+package com.synergy.backend.domain.coupon.service;
+
+import com.synergy.backend.domain.coupon.model.entity.Coupon;
+import com.synergy.backend.domain.coupon.model.type.CouponType;
+import com.synergy.backend.domain.coupon.repository.CouponRepository;
+import com.synergy.backend.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FetchCouponWithGradeService {
+
+    private final CouponRepository couponRepository;
+
+    public Coupon findByGradeWithRecur(Long gradeIdx) throws BaseException {
+        return couponRepository.findCouponsByGradeWithRecur(gradeIdx, CouponType.RECUR);
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/service/MemberCouponService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/service/MemberCouponService.java
@@ -1,0 +1,30 @@
+package com.synergy.backend.domain.coupon.service;
+
+import com.synergy.backend.domain.coupon.model.entity.Coupon;
+import com.synergy.backend.domain.coupon.model.entity.MemberCoupon;
+import com.synergy.backend.domain.coupon.repository.MemberCouponRepository;
+import com.synergy.backend.domain.member.model.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class MemberCouponService {
+
+    private final MemberCouponRepository memberCouponRepository;
+
+    public void publish(LocalDateTime publicationDate,
+                        LocalDateTime expirationDate,
+                        Member member, Coupon coupon) {
+        memberCouponRepository.save(MemberCoupon
+                .builder()
+                .member(member)
+                .coupon(coupon)
+                .publicationDate(publicationDate)
+                .expirationDate(expirationDate)
+                .build()
+        );
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/domain/grade/model/entity/Grade.java
+++ b/backend/src/main/java/com/synergy/backend/domain/grade/model/entity/Grade.java
@@ -1,10 +1,14 @@
 package com.synergy.backend.domain.grade.model.entity;
 
+import com.synergy.backend.domain.member.model.entity.Member;
 import com.synergy.backend.global.common.model.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "grade")
@@ -20,10 +24,13 @@ public class Grade extends BaseEntity {
     private String name;
     private Integer defaultPercent;
     private Integer gradeRange;
+
     private Integer recurPercent;
-    private Integer upgradePercent;
     private Integer recurNum;
+
+    private Integer upgradePercent;
     private Integer upgradeNum;
+
     private String imageUrl;
     private Integer conditionMin;
     private Integer conditionMax;

--- a/backend/src/main/java/com/synergy/backend/domain/grade/service/FetchMemberService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/grade/service/FetchMemberService.java
@@ -8,4 +8,7 @@ import java.util.List;
 @Service
 public interface FetchMemberService {
     public List<Member> FetchMember();
+
+    public List<Member> FetchMember(Long gradeIdx);
+
 }

--- a/backend/src/main/java/com/synergy/backend/domain/grade/service/impl/FetchAllMemberServiceImpl.java
+++ b/backend/src/main/java/com/synergy/backend/domain/grade/service/impl/FetchAllMemberServiceImpl.java
@@ -19,4 +19,9 @@ public class FetchAllMemberServiceImpl implements FetchMemberService {
     public List<Member> FetchMember() {
         return memberRepository.findAll();
     }
+
+    @Override
+    public List<Member> FetchMember(Long gradeIdx) {
+        return List.of();
+    }
 }

--- a/backend/src/main/java/com/synergy/backend/domain/grade/service/impl/FetchMemberByGradeServiceImpl.java
+++ b/backend/src/main/java/com/synergy/backend/domain/grade/service/impl/FetchMemberByGradeServiceImpl.java
@@ -6,24 +6,21 @@ import com.synergy.backend.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-public class FetchConditionMemberServiceImpl implements FetchMemberService {
+public class FetchMemberByGradeServiceImpl implements FetchMemberService {
 
     private final MemberRepository memberRepository;
 
-    //최근 구매이력이 있거나, 구매이력은 없지만 등급이 2이상인 회원
     @Override
     public List<Member> FetchMember() {
-        LocalDateTime oneMonthTime = LocalDateTime.now().minusMonths(1).withDayOfMonth(1);
-        return memberRepository.findMembersWithRecentPurchaseOrGradeAbove(oneMonthTime);
+        return List.of();
     }
 
     @Override
     public List<Member> FetchMember(Long gradeIdx) {
-        return List.of();
+        return memberRepository.findByGradeIdx(gradeIdx);
     }
 }

--- a/backend/src/main/java/com/synergy/backend/domain/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/synergy/backend/domain/member/repository/MemberRepository.java
@@ -20,4 +20,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Query("SELECT m FROM Member m WHERE (EXISTS (SELECT o FROM Orders o WHERE o.member = m AND o.modifiedAt > :oneMonth)) OR m.grade.idx >= 2")
     List<Member> findMembersWithRecentPurchaseOrGradeAbove(@Param("oneMonth") LocalDateTime oneMonth);
+
+    List<Member> findByGradeIdx(Long gradeIdx);
 }


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->
#44

## 📃요약
등급에 따른 정기 쿠폰 발급 스케줄러 
<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->

1. 기존 방식은 member 테이블과 coupon 테이블만 존재했었는데 
member -> memberCoupon <- coupon 으로 
member와 coupon을 외래키로 가진 memberCoupon 테이블을 만들어서 회원 별 쿠폰 발급 내역을 관리할 수 있게 했습니다. 

2. 스케줄러 기능은 테스트를 위해 api 연결해놓은 상태입니다.

        1. 전체 등급 조회
        3. 등급에 맞는 쿠폰 조회
        4. 등급에 해당하는 유저 리스트 조회
        5. 유저에게 쿠폰 발행
       
4가지 기능을 각각의 서비스 클래스로 구분해서 기능을 분리해놨습니다.

**3. 롤백**
스케줄러가 도중에 중단되었을 때 롤백을 하든, 중단 시점부터 다시 실행하든 해야합니다.
(중복 쿠폰 발급 문제 발생 가능성)

추후에 스프링 배치를 도입하면 offset으로 관리하기 때문에 지금 상태에서 처리하지 않아도 되겠다 생각했습니다. 





<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->

<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
