### PR TITLE
[Feat] 바로 구매하기 ,선물하기 라우터 설정

### DIFF
--- a/frontend/src/components/order/CartComponent.vue
+++ b/frontend/src/components/order/CartComponent.vue
@@ -1,35 +1,77 @@
 <template>
   <div id="__nuxt">
-    <div class="appContainer full" style="
+    <div
+      class="appContainer full"
+      style="
         --desktop-header-menu-top: 75px;
         --desktop-header-sticky-height: 76px;
         --container-background-color: #f5f5f5;
-      " data-v-4e58ad83="">
+      "
+      data-v-4e58ad83=""
+    >
       <div class="appContents" data-v-4e58ad83="">
         <!--[-->
-        <div data-v-8fded032="" class="Cart" style="--desktop-cart-header-height: 48px">
-          <div data-v-a5290452="" data-v-8fded032="" class="PageCartDesktop"
-            style="--desktop-cart-fab-width: undefinedpx">
+        <div
+          data-v-8fded032=""
+          class="Cart"
+          style="--desktop-cart-header-height: 48px"
+        >
+          <div
+            data-v-a5290452=""
+            data-v-8fded032=""
+            class="PageCartDesktop"
+            style="--desktop-cart-fab-width: undefinedpx"
+          >
             <!---->
             <!-- 로딩창 -->
-            <div v-if="loading" class="BaseOverlay z-[1000]" style="
+            <div
+              v-if="loading"
+              class="BaseOverlay z-[1000]"
+              style="
                 --BaseOverlay-position: fixed;
                 --BaseOverlay-background: rgba(245, 245, 245, 0.6);
                 --BaseOverlay-blur: blur(0px);
-              " data-v-546911c4="" data-v-a5290452="">
+              "
+              data-v-546911c4=""
+              data-v-a5290452=""
+            >
               <div class="BaseOverlay__scrim" data-v-546911c4=""></div>
               <div class="BaseOverlay__content" data-v-546911c4="">
-                <div class="flex justify-center items-center" data-v-a5290452="">
+                <div
+                  class="flex justify-center items-center"
+                  data-v-a5290452=""
+                >
                   <div class="relative w-full" data-v-a5290452="">
-                    <div class="BaseProgressIndicator flex justify-center items-center w-full h-[108px]"
-                      data-v-a5290452="" data-v-3e1417ba="">
-                      <div class="BaseLoaderCircle" style="width: 48px; height: 48px" data-v-d3ab2c08=""
-                        data-v-3e1417ba="">
-                        <svg viewBox="0 0 50 50" class="BaseLoaderCircle__inner" data-v-d3ab2c08="">
-                          <circle class="BaseLoaderCircle__innerCircle BaseLoaderCircle__innerCircle--underlay" cx="50%"
-                            cy="50%" r="20" data-v-d3ab2c08=""></circle>
-                          <circle class="BaseLoaderCircle__innerCircle BaseLoaderCircle__innerCircle--overlay" cx="50%"
-                            cy="50%" r="20" data-v-d3ab2c08=""></circle>
+                    <div
+                      class="BaseProgressIndicator flex justify-center items-center w-full h-[108px]"
+                      data-v-a5290452=""
+                      data-v-3e1417ba=""
+                    >
+                      <div
+                        class="BaseLoaderCircle"
+                        style="width: 48px; height: 48px"
+                        data-v-d3ab2c08=""
+                        data-v-3e1417ba=""
+                      >
+                        <svg
+                          viewBox="0 0 50 50"
+                          class="BaseLoaderCircle__inner"
+                          data-v-d3ab2c08=""
+                        >
+                          <circle
+                            class="BaseLoaderCircle__innerCircle BaseLoaderCircle__innerCircle--underlay"
+                            cx="50%"
+                            cy="50%"
+                            r="20"
+                            data-v-d3ab2c08=""
+                          ></circle>
+                          <circle
+                            class="BaseLoaderCircle__innerCircle BaseLoaderCircle__innerCircle--overlay"
+                            cx="50%"
+                            cy="50%"
+                            r="20"
+                            data-v-d3ab2c08=""
+                          ></circle>
                         </svg>
                       </div>
                     </div>
@@ -38,8 +80,14 @@
               </div>
             </div>
             <!-- 장바구니  01장바구니 > 주문 > 결제 -->
-            <div data-v-a5290452="" class="flex flex-col items-center white--background py-[30px]">
-              <div data-v-a5290452="" class="flex justify-between h-[34px] w-[1280px]">
+            <div
+              data-v-a5290452=""
+              class="flex flex-col items-center white--background py-[30px]"
+            >
+              <div
+                data-v-a5290452=""
+                class="flex justify-between h-[34px] w-[1280px]"
+              >
                 <div data-v-a5290452="" class="headline4-bold-small">
                   장바구니
                 </div>
@@ -123,23 +171,40 @@
                   </div>
                 </div> -->
 
-                <div data-v-efa8f703="" data-v-a5290452="" class="DesktopOrderStepper">
-                  <div data-v-efa8f703="" class="flex DesktopOrderStepper--active">
+                <div
+                  data-v-efa8f703=""
+                  data-v-a5290452=""
+                  class="DesktopOrderStepper"
+                >
+                  <div
+                    data-v-efa8f703=""
+                    class="flex DesktopOrderStepper--active"
+                  >
                     <div data-v-efa8f703="" class="mr-[8px]">01</div>
                     <div data-v-efa8f703="" class="mr-[8px]">장바구니</div>
                   </div>
-                  <svg data-v-6d2bd019="" data-v-efa8f703="" width="24" height="24" viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg" class="BaseIcon mr-[8px] last:hidden" style="
+                  <svg
+                    data-v-6d2bd019=""
+                    data-v-efa8f703=""
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="BaseIcon mr-[8px] last:hidden"
+                    style="
                       width: 20px;
                       height: 20px;
                       opacity: 1;
                       fill: currentcolor;
                       --BaseIcon-color: #d9d9d9;
-                    ">
+                    "
+                  >
                     <g clip-path="url(#clip0_124_2947)">
-                      <path fill-rule="evenodd" clip-rule="evenodd"
-                        d="M9.53039 5.46973L15.5304 11.4697C15.7967 11.736 15.8209 12.1527 15.603 12.4463L15.5304 12.5304L9.53039 18.5304L8.46973 17.4697L13.9391 12.0001L8.46973 6.53039L9.53039 5.46973Z">
-                      </path>
+                      <path
+                        fill-rule="evenodd"
+                        clip-rule="evenodd"
+                        d="M9.53039 5.46973L15.5304 11.4697C15.7967 11.736 15.8209 12.1527 15.603 12.4463L15.5304 12.5304L9.53039 18.5304L8.46973 17.4697L13.9391 12.0001L8.46973 6.53039L9.53039 5.46973Z"
+                      ></path>
                     </g>
                     <defs>
                       <clipPath id="clip0_124_2947">
@@ -151,18 +216,28 @@
                     <div data-v-efa8f703="" class="mr-[8px]">02</div>
                     <div data-v-efa8f703="" class="mr-[8px]">주문 결제</div>
                   </div>
-                  <svg data-v-6d2bd019="" data-v-efa8f703="" width="24" height="24" viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg" class="BaseIcon mr-[8px] last:hidden" style="
+                  <svg
+                    data-v-6d2bd019=""
+                    data-v-efa8f703=""
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="BaseIcon mr-[8px] last:hidden"
+                    style="
                       width: 20px;
                       height: 20px;
                       opacity: 1;
                       fill: currentcolor;
                       --BaseIcon-color: #d9d9d9;
-                    ">
+                    "
+                  >
                     <g clip-path="url(#clip0_124_2947)">
-                      <path fill-rule="evenodd" clip-rule="evenodd"
-                        d="M9.53039 5.46973L15.5304 11.4697C15.7967 11.736 15.8209 12.1527 15.603 12.4463L15.5304 12.5304L9.53039 18.5304L8.46973 17.4697L13.9391 12.0001L8.46973 6.53039L9.53039 5.46973Z">
-                      </path>
+                      <path
+                        fill-rule="evenodd"
+                        clip-rule="evenodd"
+                        d="M9.53039 5.46973L15.5304 11.4697C15.7967 11.736 15.8209 12.1527 15.603 12.4463L15.5304 12.5304L9.53039 18.5304L8.46973 17.4697L13.9391 12.0001L8.46973 6.53039L9.53039 5.46973Z"
+                      ></path>
                     </g>
                     <defs>
                       <clipPath id="clip0_124_2947">
@@ -174,18 +249,28 @@
                     <div data-v-efa8f703="" class="mr-[8px]">03</div>
                     <div data-v-efa8f703="" class="mr-[8px]">주문 완료</div>
                   </div>
-                  <svg data-v-6d2bd019="" data-v-efa8f703="" width="24" height="24" viewBox="0 0 24 24"
-                    xmlns="http://www.w3.org/2000/svg" class="BaseIcon mr-[8px] last:hidden" style="
+                  <svg
+                    data-v-6d2bd019=""
+                    data-v-efa8f703=""
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="BaseIcon mr-[8px] last:hidden"
+                    style="
                       width: 20px;
                       height: 20px;
                       opacity: 1;
                       fill: currentcolor;
                       --BaseIcon-color: #d9d9d9;
-                    ">
+                    "
+                  >
                     <g clip-path="url(#clip0_124_2947)">
-                      <path fill-rule="evenodd" clip-rule="evenodd"
-                        d="M9.53039 5.46973L15.5304 11.4697C15.7967 11.736 15.8209 12.1527 15.603 12.4463L15.5304 12.5304L9.53039 18.5304L8.46973 17.4697L13.9391 12.0001L8.46973 6.53039L9.53039 5.46973Z">
-                      </path>
+                      <path
+                        fill-rule="evenodd"
+                        clip-rule="evenodd"
+                        d="M9.53039 5.46973L15.5304 11.4697C15.7967 11.736 15.8209 12.1527 15.603 12.4463L15.5304 12.5304L9.53039 18.5304L8.46973 17.4697L13.9391 12.0001L8.46973 6.53039L9.53039 5.46973Z"
+                      ></path>
                     </g>
                     <defs>
                       <clipPath id="clip0_124_2947">
@@ -200,45 +285,75 @@
             <!-- 전체 선택 -->
             <div data-v-a5290452="" class="PageCartDesktop__allCheck">
               <div data-v-a5290452="" class="flex justify-start w-[1280px]">
-                <div data-v-a5290452=""
-                  class="flex items-center justify-between white--background w-[850px] PageCartDesktop__allCheckControl">
+                <div
+                  data-v-a5290452=""
+                  class="flex items-center justify-between white--background w-[850px] PageCartDesktop__allCheckControl"
+                >
                   <div>
-                    <label data-v-ee180726="" :class="getCheckboxLabelClass(isAllSelected)"
-                      style="--BaseCheckbox--label-margin: 8">
+                    <label
+                      data-v-ee180726=""
+                      :class="getCheckboxLabelClass(isAllSelected)"
+                      style="--BaseCheckbox--label-margin: 8"
+                    >
                       <div data-v-ee180726="" class="BaseCheckbox__wrapper">
-                        <input :checked="isAllSelected" @change="toggleAll" data-v-ee180726=""
-                          class="BaseCheckbox__input" type="checkbox" /><span data-v-ee180726=""
-                          class="BaseCheckbox__button"><svg data-v-6d2bd019="" data-v-ee180726="" width="24" height="24"
-                            viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="BaseIcon BaseCheckbox__icon"
-                            :style="getCheckboxSvgStyle(isAllSelected)">
+                        <input
+                          :checked="isAllSelected"
+                          @change="toggleAll"
+                          data-v-ee180726=""
+                          class="BaseCheckbox__input"
+                          type="checkbox"
+                        /><span data-v-ee180726="" class="BaseCheckbox__button"
+                          ><svg
+                            data-v-6d2bd019=""
+                            data-v-ee180726=""
+                            width="24"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                            class="BaseIcon BaseCheckbox__icon"
+                            :style="getCheckboxSvgStyle(isAllSelected)"
+                          >
                             <g clip-path="url(#clip0_2582_8708)">
-                              <path fill-rule="evenodd" clip-rule="evenodd"
-                                d="M7.76086 11.5393L10.1343 13.9131L16.2648 7.7827L17.3255 8.84336L10.6648 15.504C10.3964 15.7725 9.97496 15.7948 9.68099 15.5711L9.60419 15.504L6.7002 12.6L7.76086 11.5393Z">
-                              </path>
+                              <path
+                                fill-rule="evenodd"
+                                clip-rule="evenodd"
+                                d="M7.76086 11.5393L10.1343 13.9131L16.2648 7.7827L17.3255 8.84336L10.6648 15.504C10.3964 15.7725 9.97496 15.7948 9.68099 15.5711L9.60419 15.504L6.7002 12.6L7.76086 11.5393Z"
+                              ></path>
                             </g>
                             <defs>
                               <clipPath id="clip0_2582_8708">
                                 <rect width="24" height="24"></rect>
                               </clipPath>
-                            </defs>
-                          </svg></span><span data-v-ee180726="" class="BaseCheckbox__text"
-                          style="color: rgb(51, 51, 51)">전체선택</span>
+                            </defs></svg></span
+                        ><span
+                          data-v-ee180726=""
+                          class="BaseCheckbox__text"
+                          style="color: rgb(51, 51, 51)"
+                          >전체선택</span
+                        >
                       </div>
                     </label>
                   </div>
                   <div>
-                    <button data-v-524f63ea="" data-v-7940d6dd="" type="outline"
-                      class="CoreButton BaseButtonRectangle body3-regular-small BaseButtonRectangle__outline" style="
+                    <button
+                      data-v-524f63ea=""
+                      data-v-7940d6dd=""
+                      type="outline"
+                      class="CoreButton BaseButtonRectangle body3-regular-small BaseButtonRectangle__outline"
+                      style="
                         background-color: rgb(255, 255, 255);
                         color: rgb(51, 51, 51);
                         height: 28px;
                         flex-direction: row;
                         --core-button-padding-x: 8;
                         --button-rectangle-border-color: #acacac;
-                      ">
+                      "
+                    >
                       <!----><!---->
                       <div data-v-524f63ea="" class="inline-flex items-center">
-                        <span data-v-524f63ea="" class="CoreButton__text">선택삭제</span>
+                        <span data-v-524f63ea="" class="CoreButton__text"
+                          >선택삭제</span
+                        >
                       </div>
                     </button>
                   </div>
@@ -250,58 +365,115 @@
             <div data-v-a5290452="" class="flex justify-center mb-[30px]">
               <div data-v-a5290452="" class="w-[850px] min-h-[550px]">
                 <!-- 장바구니 작가 반복 -->
-                <div v-for="atelier in cartList" :key="atelier.atelierIdx" data-v-db78b45c="" data-v-a5290452=""
-                  class="CartArtist CartArtist--sticky" id="cart_artist_eacceac9-7992-43db-af29-fb383c7fced9"
-                  style="--desktop-cart-artist-sticky-height: 78px">
+                <div
+                  v-for="atelier in cartList"
+                  :key="atelier.atelierIdx"
+                  data-v-db78b45c=""
+                  data-v-a5290452=""
+                  class="CartArtist CartArtist--sticky"
+                  id="cart_artist_eacceac9-7992-43db-af29-fb383c7fced9"
+                  style="--desktop-cart-artist-sticky-height: 78px"
+                >
                   <!-- 공방 이름 -->
                   <div data-v-db78b45c="" class="CartArtist__header">
                     <div data-v-db78b45c="" class="CartArtist__headerInner">
-                      <div data-v-db78b45c="" class="flex items-center justify-between h-[56px]">
+                      <div
+                        data-v-db78b45c=""
+                        class="flex items-center justify-between h-[56px]"
+                      >
                         <div data-v-db78b45c="" class="flex items-center">
-                          <label data-v-ee180726="" data-v-db78b45c="" :class="getCheckboxLabelClass(
-                            isAtelierSelected(atelier.productList)
-                          )
-                            " style="--BaseCheckbox--label-margin: 8">
-                            <div data-v-ee180726="" class="BaseCheckbox__wrapper">
-                              <input :checked="isAtelierSelected(atelier.productList)
-                                " @change="toggleAtelier(atelier.productList, atelier.atelierIdx)" data-v-ee180726=""
-                                class="BaseCheckbox__input" type="checkbox" /><span data-v-ee180726=""
-                                class="BaseCheckbox__button"><svg data-v-6d2bd019="" data-v-ee180726="" width="24"
-                                  height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
-                                  class="BaseIcon BaseCheckbox__icon" :style="getCheckboxSvgStyle(
-                                    isAtelierSelected(atelier.productList)
+                          <label
+                            data-v-ee180726=""
+                            data-v-db78b45c=""
+                            :class="
+                              getCheckboxLabelClass(
+                                isAtelierSelected(atelier.productList)
+                              )
+                            "
+                            style="--BaseCheckbox--label-margin: 8"
+                          >
+                            <div
+                              data-v-ee180726=""
+                              class="BaseCheckbox__wrapper"
+                            >
+                              <input
+                                :checked="
+                                  isAtelierSelected(atelier.productList)
+                                "
+                                @change="
+                                  toggleAtelier(
+                                    atelier.productList,
+                                    atelier.atelierIdx
                                   )
-                                    ">
+                                "
+                                data-v-ee180726=""
+                                class="BaseCheckbox__input"
+                                type="checkbox"
+                              /><span
+                                data-v-ee180726=""
+                                class="BaseCheckbox__button"
+                                ><svg
+                                  data-v-6d2bd019=""
+                                  data-v-ee180726=""
+                                  width="24"
+                                  height="24"
+                                  viewBox="0 0 24 24"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  class="BaseIcon BaseCheckbox__icon"
+                                  :style="
+                                    getCheckboxSvgStyle(
+                                      isAtelierSelected(atelier.productList)
+                                    )
+                                  "
+                                >
                                   <g clip-path="url(#clip0_2582_8708)">
-                                    <path fill-rule="evenodd" clip-rule="evenodd"
-                                      d="M7.76086 11.5393L10.1343 13.9131L16.2648 7.7827L17.3255 8.84336L10.6648 15.504C10.3964 15.7725 9.97496 15.7948 9.68099 15.5711L9.60419 15.504L6.7002 12.6L7.76086 11.5393Z">
-                                    </path>
+                                    <path
+                                      fill-rule="evenodd"
+                                      clip-rule="evenodd"
+                                      d="M7.76086 11.5393L10.1343 13.9131L16.2648 7.7827L17.3255 8.84336L10.6648 15.504C10.3964 15.7725 9.97496 15.7948 9.68099 15.5711L9.60419 15.504L6.7002 12.6L7.76086 11.5393Z"
+                                    ></path>
                                   </g>
                                   <defs>
                                     <clipPath id="clip0_2582_8708">
                                       <rect width="24" height="24"></rect>
                                     </clipPath>
-                                  </defs>
-                                </svg></span><span data-v-ee180726="" class="BaseCheckbox__text"
-                                style="color: rgb(51, 51, 51)"></span>
+                                  </defs></svg></span
+                              ><span
+                                data-v-ee180726=""
+                                class="BaseCheckbox__text"
+                                style="color: rgb(51, 51, 51)"
+                              ></span>
                             </div>
                           </label>
                           <div data-v-db78b45c="" class="flex cursor-pointer">
-                            <div data-v-db78b45c="" class="subtitle3-bold-medium line-clamp-1">
+                            <div
+                              data-v-db78b45c=""
+                              class="subtitle3-bold-medium line-clamp-1"
+                            >
                               {{ atelier.atelierName }}
                             </div>
-                            <svg data-v-6d2bd019="" data-v-db78b45c="" width="24" height="24" viewBox="0 0 24 24"
-                              xmlns="http://www.w3.org/2000/svg" class="BaseIcon" style="
+                            <svg
+                              data-v-6d2bd019=""
+                              data-v-db78b45c=""
+                              width="24"
+                              height="24"
+                              viewBox="0 0 24 24"
+                              xmlns="http://www.w3.org/2000/svg"
+                              class="BaseIcon"
+                              style="
                                 width: 24px;
                                 height: 24px;
                                 opacity: 1;
                                 fill: currentcolor;
                                 --BaseIcon-color: #333333;
-                              ">
+                              "
+                            >
                               <g clip-path="url(#clip0_124_2947)">
-                                <path fill-rule="evenodd" clip-rule="evenodd"
-                                  d="M9.53039 5.46973L15.5304 11.4697C15.7967 11.736 15.8209 12.1527 15.603 12.4463L15.5304 12.5304L9.53039 18.5304L8.46973 17.4697L13.9391 12.0001L8.46973 6.53039L9.53039 5.46973Z">
-                                </path>
+                                <path
+                                  fill-rule="evenodd"
+                                  clip-rule="evenodd"
+                                  d="M9.53039 5.46973L15.5304 11.4697C15.7967 11.736 15.8209 12.1527 15.603 12.4463L15.5304 12.5304L9.53039 18.5304L8.46973 17.4697L13.9391 12.0001L8.46973 6.53039L9.53039 5.46973Z"
+                                ></path>
                               </g>
                               <defs>
                                 <clipPath id="clip0_124_2947">
@@ -313,28 +485,53 @@
                         </div>
                         <div data-v-db78b45c="" class="flex flex-col items-end">
                           <div>
-                            <div data-v-a1957620=""
-                              class="BaseDecorateText transform-gpu whitespace-pre inline flex ml-[4px]">
-                              <span data-v-a1957620="" class="DecorateText__badge"><!---->
-                                <div data-v-c3bdd300="" data-v-a1957620="" class="BaseBadgeFreeShipping"
-                                  style="--icon-width: 48; --icon-height: 18">
-                                  <div data-v-c3bdd300="" class="BaseBadgeFreeShipping__icon"></div>
+                            <div
+                              data-v-a1957620=""
+                              class="BaseDecorateText transform-gpu whitespace-pre inline flex ml-[4px]"
+                            >
+                              <span
+                                data-v-a1957620=""
+                                class="DecorateText__badge"
+                                ><!---->
+                                <div
+                                  data-v-c3bdd300=""
+                                  data-v-a1957620=""
+                                  class="BaseBadgeFreeShipping"
+                                  style="--icon-width: 48; --icon-height: 18"
+                                >
+                                  <div
+                                    data-v-c3bdd300=""
+                                    class="BaseBadgeFreeShipping__icon"
+                                  ></div>
                                 </div>
                               </span>
                             </div>
                           </div>
-                          <div class="flex items-center justify-end mt-[4px]"></div>
+                          <div
+                            class="flex items-center justify-end mt-[4px]"
+                          ></div>
                         </div>
                       </div>
-                      <div data-v-db78b45c="" class="pb-[8px] h-[14px]" style="display: none">
-                        <div data-v-cb06afdd="" data-v-db78b45c=""
-                          class="ProgressBar__container ProgressBar__colorType--blue" style="
+                      <div
+                        data-v-db78b45c=""
+                        class="pb-[8px] h-[14px]"
+                        style="display: none"
+                      >
+                        <div
+                          data-v-cb06afdd=""
+                          data-v-db78b45c=""
+                          class="ProgressBar__container ProgressBar__colorType--blue"
+                          style="
                             --progress-bar-height: 6px;
                             --progress-bar-bar-rate: 100%;
                             --progress-bar-border-radius: 3px;
-                          ">
+                          "
+                        >
                           <div data-v-cb06afdd="" class="ProgressBar">
-                            <div data-v-cb06afdd="" class="ProgressBar__bar transform-gpu"></div>
+                            <div
+                              data-v-cb06afdd=""
+                              class="ProgressBar__bar transform-gpu"
+                            ></div>
                           </div>
                         </div>
                       </div>
@@ -343,62 +540,119 @@
 
                   <!-- 공방 컨텐츠 -->
                   <div data-v-db78b45c="" class="CartArtist__contents">
-                    <hr data-v-6ef4cf18="" data-v-db78b45c="" class="BaseDivider" style="--border-color: #f5f5f5" />
+                    <hr
+                      data-v-6ef4cf18=""
+                      data-v-db78b45c=""
+                      class="BaseDivider"
+                      style="--border-color: #f5f5f5"
+                    />
                     <div data-v-db78b45c="">
                       <!---->
 
                       <!-- 상품 반복 -->
-                      <div v-for="product in atelier.productList" :key="product.productIdx" data-v-8cd67775=""
-                        data-v-db78b45c="">
-                        <div data-v-8cd67775="" class="flex items-start justify-between w-full py-[12px] px-[16px]">
+                      <div
+                        v-for="product in atelier.productList"
+                        :key="product.productIdx"
+                        data-v-8cd67775=""
+                        data-v-db78b45c=""
+                      >
+                        <div
+                          data-v-8cd67775=""
+                          class="flex items-start justify-between w-full py-[12px] px-[16px]"
+                        >
                           <!-- 사진 -->
                           <div data-v-8cd67775="" class="flex items-start">
-                            <label data-v-ee180726="" data-v-8cd67775="" :class="getCheckboxLabelClass(
-                              isProductSelected(product.optionList)
-                            )
-                              " style="--BaseCheckbox--label-margin: 8">
-                              <div data-v-ee180726="" class="BaseCheckbox__wrapper">
-                                <input :checked="isProductSelected(product.optionList)
-                                  " @change="
+                            <label
+                              data-v-ee180726=""
+                              data-v-8cd67775=""
+                              :class="
+                                getCheckboxLabelClass(
+                                  isProductSelected(product.optionList)
+                                )
+                              "
+                              style="--BaseCheckbox--label-margin: 8"
+                            >
+                              <div
+                                data-v-ee180726=""
+                                class="BaseCheckbox__wrapper"
+                              >
+                                <input
+                                  :checked="
+                                    isProductSelected(product.optionList)
+                                  "
+                                  @change="
                                     toggleProduct(
                                       product.optionList,
                                       product.productIdx,
                                       atelier.atelierIdx
                                     )
-                                    " data-v-ee180726="" class="BaseCheckbox__input" type="checkbox" /><span
-                                  data-v-ee180726="" class="BaseCheckbox__button"><svg data-v-6d2bd019=""
-                                    data-v-ee180726="" width="24" height="24" viewBox="0 0 24 24"
-                                    xmlns="http://www.w3.org/2000/svg" class="BaseIcon BaseCheckbox__icon" :style="getCheckboxSvgStyle(
-                                      isProductSelected(product.optionList)
-                                    )
-                                      ">
+                                  "
+                                  data-v-ee180726=""
+                                  class="BaseCheckbox__input"
+                                  type="checkbox"
+                                /><span
+                                  data-v-ee180726=""
+                                  class="BaseCheckbox__button"
+                                  ><svg
+                                    data-v-6d2bd019=""
+                                    data-v-ee180726=""
+                                    width="24"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    class="BaseIcon BaseCheckbox__icon"
+                                    :style="
+                                      getCheckboxSvgStyle(
+                                        isProductSelected(product.optionList)
+                                      )
+                                    "
+                                  >
                                     <g clip-path="url(#clip0_2582_8708)">
-                                      <path fill-rule="evenodd" clip-rule="evenodd"
-                                        d="M7.76086 11.5393L10.1343 13.9131L16.2648 7.7827L17.3255 8.84336L10.6648 15.504C10.3964 15.7725 9.97496 15.7948 9.68099 15.5711L9.60419 15.504L6.7002 12.6L7.76086 11.5393Z">
-                                      </path>
+                                      <path
+                                        fill-rule="evenodd"
+                                        clip-rule="evenodd"
+                                        d="M7.76086 11.5393L10.1343 13.9131L16.2648 7.7827L17.3255 8.84336L10.6648 15.504C10.3964 15.7725 9.97496 15.7948 9.68099 15.5711L9.60419 15.504L6.7002 12.6L7.76086 11.5393Z"
+                                      ></path>
                                     </g>
                                     <defs>
                                       <clipPath id="clip0_2582_8708">
                                         <rect width="24" height="24"></rect>
                                       </clipPath>
-                                    </defs>
-                                  </svg></span><span data-v-ee180726="" class="BaseCheckbox__text"
-                                  style="color: rgb(51, 51, 51)"></span>
+                                    </defs></svg></span
+                                ><span
+                                  data-v-ee180726=""
+                                  class="BaseCheckbox__text"
+                                  style="color: rgb(51, 51, 51)"
+                                ></span>
                               </div>
                             </label>
-                            <div data-v-8cd67775="" class="CartArtistProduct__image">
-                              <div data-v-24b1dfb3="" data-v-8cd67775=""
-                                class="BaseImage BaseImage__fixedWidth BaseImage__fixedHeight cursor-pointer" style="
+                            <div
+                              data-v-8cd67775=""
+                              class="CartArtistProduct__image"
+                            >
+                              <div
+                                data-v-24b1dfb3=""
+                                data-v-8cd67775=""
+                                class="BaseImage BaseImage__fixedWidth BaseImage__fixedHeight cursor-pointer"
+                                style="
                                   --BaseImage-width: 64;
                                   --BaseImage-height: 64;
                                   --BaseImage-radius: 2;
-                                ">
-                                <div data-v-24b1dfb3="" class="BaseImage__image" style="
+                                "
+                              >
+                                <div
+                                  data-v-24b1dfb3=""
+                                  class="BaseImage__image"
+                                  style="
                                     background-image: url('https://image.idus.com/image/files/eb752e371c5b459097e189311ffddd46_320.jpg');
-                                  ">
-                                  <img data-v-24b1dfb3=""
+                                  "
+                                >
+                                  <img
+                                    data-v-24b1dfb3=""
                                     src="https://image.idus.com/image/files/eb752e371c5b459097e189311ffddd46_320.jpg"
-                                    class="hidden" loading="lazy" />
+                                    class="hidden"
+                                    loading="lazy"
+                                  />
                                 </div>
                               </div>
                               <!---->
@@ -406,52 +660,98 @@
                           </div>
 
                           <!-- 상품 설명 본문 -->
-                          <div data-v-8cd67775="" class="flex flex-col flex-auto ml-[12px]" style="text-align: left">
+                          <div
+                            data-v-8cd67775=""
+                            class="flex flex-col flex-auto ml-[12px]"
+                            style="text-align: left"
+                          >
                             <!-- 상품 제목 -->
                             <div data-v-8cd67775="" class="flex cursor-pointer">
-                              <div data-v-8cd67775="" class="flex flex-col flex-auto">
+                              <div
+                                data-v-8cd67775=""
+                                class="flex flex-col flex-auto"
+                              >
                                 <div data-v-8cd67775="" class="flex mb-[4px]">
-                                  <div data-v-1cb18953="" data-v-8cd67775=""
+                                  <div
+                                    data-v-1cb18953=""
+                                    data-v-8cd67775=""
                                     class="BaseBadge BaseBadge__style--membershipTextColor BaseBadge__style--membershipBackgroundColor BaseBadge__style--round flex mr-[4px] last:ml-0"
                                     style="
                                       --badge-color: #ff4b50;
                                       --badge-background-color: #fff2f4;
-                                    ">
-                                    <img data-v-1cb18953=""
+                                    "
+                                  >
+                                    <img
+                                      data-v-1cb18953=""
                                       src="https://cdn.idus.kr/static/common/images/20240522/063418_icon_discount.png"
-                                      class="h-[12px] mr-[2px]" />
-                                    <div data-v-1cb18953="" class="BaseBadge__text">
+                                      class="h-[12px] mr-[2px]"
+                                    />
+                                    <div
+                                      data-v-1cb18953=""
+                                      class="BaseBadge__text"
+                                    >
                                       10% 즉시할인
                                     </div>
                                   </div>
                                 </div>
-                                <div data-v-8cd67775="" class="body1-regular-small">
+                                <div
+                                  data-v-8cd67775=""
+                                  class="body1-regular-small"
+                                >
                                   {{ product.productName }}
                                 </div>
-                                <div data-v-8cd67775="" class="body3-regular-medium gray-999--text">
+                                <div
+                                  data-v-8cd67775=""
+                                  class="body3-regular-medium gray-999--text"
+                                >
                                   주문시 제작
                                 </div>
                               </div>
                               <!---->
                             </div>
 
-                            <div data-v-8cd67775="" class="flex flex-col w-full">
+                            <div
+                              data-v-8cd67775=""
+                              class="flex flex-col w-full"
+                            >
                               <!-- 같은 상품의 여러 옵션들 -->
-                              <div v-for="option in product.optionList" :key="option.cartIdx" data-v-6df967a0=""
-                                data-v-8cd67775="" class="flex justify-between w-full py-[16px]">
+                              <div
+                                v-for="option in product.optionList"
+                                :key="option.cartIdx"
+                                data-v-6df967a0=""
+                                data-v-8cd67775=""
+                                class="flex justify-between w-full py-[16px]"
+                              >
                                 <!-- 상품 옵션 리스트 whitespace-pre-line 옵션 뻄-->
-                                <div v data-v-6df967a0="" class="body3-regular-small gray-666--text">
-                                  <p v-for="optionDetail in option.subOptionsList" :key="optionDetail.cartIdx">
+                                <div
+                                  v
+                                  data-v-6df967a0=""
+                                  class="body3-regular-small gray-666--text"
+                                >
+                                  <p
+                                    v-for="optionDetail in option.subOptionsList"
+                                    :key="optionDetail.cartIdx"
+                                  >
                                     - {{ optionDetail.majorOptionName }} :
                                     {{ optionDetail.subOptionName }}
                                   </p>
                                 </div>
 
                                 <!-- 옵션 선택 -->
-                                <div data-v-6df967a0="" class="flex items-start justify-between">
+                                <div
+                                  data-v-6df967a0=""
+                                  class="flex items-start justify-between"
+                                >
                                   <div data-v-6df967a0="" class="flex flex-col">
-                                    <div data-v-6df967a0="" class="flex items-center pl-[20px]">
-                                      <button data-v-524f63ea="" data-v-7940d6dd="" data-v-6df967a0="" type="outline"
+                                    <div
+                                      data-v-6df967a0=""
+                                      class="flex items-center pl-[20px]"
+                                    >
+                                      <button
+                                        data-v-524f63ea=""
+                                        data-v-7940d6dd=""
+                                        data-v-6df967a0=""
+                                        type="outline"
                                         class="CoreButton BaseButtonRectangle body3-regular-small BaseButtonRectangle__outline min-w-[60px]"
                                         style="
                                           background-color: rgb(255, 255, 255);
@@ -460,98 +760,175 @@
                                           flex-direction: row;
                                           --core-button-padding-x: 8;
                                           --button-rectangle-border-color: #acacac;
-                                        ">
+                                        "
+                                      >
                                         <!----><!---->
-                                        <div data-v-524f63ea="" class="inline-flex items-center">
-                                          <span data-v-524f63ea="" class="CoreButton__text">옵션변경</span>
+                                        <div
+                                          data-v-524f63ea=""
+                                          class="inline-flex items-center"
+                                        >
+                                          <span
+                                            data-v-524f63ea=""
+                                            class="CoreButton__text"
+                                            >옵션변경</span
+                                          >
                                         </div>
                                       </button>
-                                      <div data-v-c2d3b141="" data-v-6df967a0="" class="Count ml-[8px]">
-                                        <div data-v-c2d3b141="" class="h-full border-r-[1px] border-[#f5f5f5]">
-                                          <button @click="
-                                            updateQuantity(
-                                              option.cartIdx,
-                                              option.count - 1
-                                            )
-                                            " data-v-524f63ea="" data-v-778c1d9b="" data-v-c2d3b141="" type="button"
-                                            class="CoreButton CoreButton BaseButtonIcon gray-f5--background" style="
+                                      <div
+                                        data-v-c2d3b141=""
+                                        data-v-6df967a0=""
+                                        class="Count ml-[8px]"
+                                      >
+                                        <div
+                                          data-v-c2d3b141=""
+                                          class="h-full border-r-[1px] border-[#f5f5f5]"
+                                        >
+                                          <button
+                                            @click="
+                                              updateQuantity(
+                                                option.cartIdx,
+                                                option.count - 1
+                                              )
+                                            "
+                                            data-v-524f63ea=""
+                                            data-v-778c1d9b=""
+                                            data-v-c2d3b141=""
+                                            type="button"
+                                            class="CoreButton CoreButton BaseButtonIcon gray-f5--background"
+                                            style="
                                               background-color: transparent;
                                               height: 30px;
                                               width: 30px;
                                               flex-direction: column;
-                                            ">
-                                            <!----><svg data-v-6d2bd019="" data-v-524f63ea="" width="24" height="24"
-                                              viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
-                                              class="BaseIcon CoreButton__icon" style="
+                                            "
+                                          >
+                                            <!----><svg
+                                              data-v-6d2bd019=""
+                                              data-v-524f63ea=""
+                                              width="24"
+                                              height="24"
+                                              viewBox="0 0 24 24"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              class="BaseIcon CoreButton__icon"
+                                              style="
                                                 width: 20px;
                                                 height: 20px;
                                                 opacity: 1;
                                                 fill: currentcolor;
                                                 --BaseIcon-color: #333333;
                                                 margin-bottom: 0px;
-                                              ">
-                                              <g clip-path="url(#clip0_124_2961)">
-                                                <path fill-rule="evenodd" clip-rule="evenodd"
-                                                  d="M19 11.25V12.75H5V11.25H19Z"></path>
+                                              "
+                                            >
+                                              <g
+                                                clip-path="url(#clip0_124_2961)"
+                                              >
+                                                <path
+                                                  fill-rule="evenodd"
+                                                  clip-rule="evenodd"
+                                                  d="M19 11.25V12.75H5V11.25H19Z"
+                                                ></path>
                                               </g>
                                               <defs>
                                                 <clipPath id="clip0_124_2961">
-                                                  <rect width="24" height="24"></rect>
+                                                  <rect
+                                                    width="24"
+                                                    height="24"
+                                                  ></rect>
                                                 </clipPath>
                                               </defs>
                                             </svg>
-                                            <div data-v-524f63ea="" class="inline-flex items-center">
+                                            <div
+                                              data-v-524f63ea=""
+                                              class="inline-flex items-center"
+                                            >
                                               <!---->
                                             </div>
                                           </button>
                                         </div>
                                         <!-- 숫자 입력 업데이트 변경해야할 부분  -->
-                                        <select @click="
-                                          updateQuantity(
-                                            option.cartIdx,
-                                            option.count
-                                          )
-                                          " data-v-c2d3b141="" class="Count__select" v-model="option.count">
-                                          <option v-for="n in 100" :key="n" :value="n">
+                                        <select
+                                          @click="
+                                            updateQuantity(
+                                              option.cartIdx,
+                                              option.count
+                                            )
+                                          "
+                                          data-v-c2d3b141=""
+                                          class="Count__select"
+                                          v-model="option.count"
+                                        >
+                                          <option
+                                            v-for="n in 100"
+                                            :key="n"
+                                            :value="n"
+                                          >
                                             {{ n }}
                                           </option>
                                         </select>
-                                        <div data-v-c2d3b141="" class="h-full border-l-[1px] border-[#f5f5f5]">
-                                          <button @click="
-                                            updateQuantity(
-                                              option.cartIdx,
-                                              option.count + 1
-                                            )
-                                            " :disabled="option.quantity <= 1" data-v-524f63ea="" data-v-778c1d9b=""
-                                            data-v-c2d3b141="" type="button" class="CoreButton BaseButtonIcon" style="
+                                        <div
+                                          data-v-c2d3b141=""
+                                          class="h-full border-l-[1px] border-[#f5f5f5]"
+                                        >
+                                          <button
+                                            @click="
+                                              updateQuantity(
+                                                option.cartIdx,
+                                                option.count + 1
+                                              )
+                                            "
+                                            :disabled="option.quantity <= 1"
+                                            data-v-524f63ea=""
+                                            data-v-778c1d9b=""
+                                            data-v-c2d3b141=""
+                                            type="button"
+                                            class="CoreButton BaseButtonIcon"
+                                            style="
                                               background-color: transparent;
                                               color: rgb(51, 51, 51);
                                               height: 30px;
                                               width: 30px;
                                               flex-direction: column;
-                                            ">
-                                            <!----><svg data-v-6d2bd019="" data-v-524f63ea="" width="24" height="24"
-                                              viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
-                                              class="BaseIcon CoreButton__icon" style="
+                                            "
+                                          >
+                                            <!----><svg
+                                              data-v-6d2bd019=""
+                                              data-v-524f63ea=""
+                                              width="24"
+                                              height="24"
+                                              viewBox="0 0 24 24"
+                                              xmlns="http://www.w3.org/2000/svg"
+                                              class="BaseIcon CoreButton__icon"
+                                              style="
                                                 width: 20px;
                                                 height: 20px;
                                                 opacity: 1;
                                                 fill: currentcolor;
                                                 --BaseIcon-color: #333333;
                                                 margin-bottom: 0px;
-                                              ">
-                                              <g clip-path="url(#clip0_124_2960)">
-                                                <path fill-rule="evenodd" clip-rule="evenodd"
-                                                  d="M12.75 5V11.25H19V12.75H12.75V19H11.25V12.75H5V11.25H11.25V5H12.75Z">
-                                                </path>
+                                              "
+                                            >
+                                              <g
+                                                clip-path="url(#clip0_124_2960)"
+                                              >
+                                                <path
+                                                  fill-rule="evenodd"
+                                                  clip-rule="evenodd"
+                                                  d="M12.75 5V11.25H19V12.75H12.75V19H11.25V12.75H5V11.25H11.25V5H12.75Z"
+                                                ></path>
                                               </g>
                                               <defs>
                                                 <clipPath id="clip0_124_2960">
-                                                  <rect width="24" height="24"></rect>
+                                                  <rect
+                                                    width="24"
+                                                    height="24"
+                                                  ></rect>
                                                 </clipPath>
                                               </defs>
                                             </svg>
-                                            <div data-v-524f63ea="" class="inline-flex items-center">
+                                            <div
+                                              data-v-524f63ea=""
+                                              class="inline-flex items-center"
+                                            >
                                               <!---->
                                             </div>
                                           </button>
@@ -560,34 +937,55 @@
                                     </div>
                                     <!---->
                                   </div>
-                                  <div data-v-6df967a0="" class="flex items-center justify-between h-[32px]">
+                                  <div
+                                    data-v-6df967a0=""
+                                    class="flex items-center justify-between h-[32px]"
+                                  >
                                     <div data-v-6df967a0="">
                                       <!---->
-                                      <div data-v-6df967a0="" class="body1-bold-small w-[120px] ml-[20px] text-right">
+                                      <div
+                                        data-v-6df967a0=""
+                                        class="body1-bold-small w-[120px] ml-[20px] text-right"
+                                      >
                                         {{ option.price * option.count }}원
                                       </div>
                                     </div>
-                                    <button data-v-524f63ea="" data-v-778c1d9b="" data-v-6df967a0="" type="button"
-                                      class="CoreButton BaseButtonIcon ml-[12px]" style="
+                                    <button
+                                      data-v-524f63ea=""
+                                      data-v-778c1d9b=""
+                                      data-v-6df967a0=""
+                                      type="button"
+                                      class="CoreButton BaseButtonIcon ml-[12px]"
+                                      style="
                                         background-color: transparent;
                                         color: rgb(153, 153, 153);
                                         height: 20px;
                                         flex-direction: column;
-                                      ">
-                                      <!----><svg data-v-6d2bd019="" data-v-524f63ea="" width="24" height="24"
-                                        viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
-                                        class="BaseIcon CoreButton__icon" style="
+                                      "
+                                    >
+                                      <!----><svg
+                                        data-v-6d2bd019=""
+                                        data-v-524f63ea=""
+                                        width="24"
+                                        height="24"
+                                        viewBox="0 0 24 24"
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        class="BaseIcon CoreButton__icon"
+                                        style="
                                           width: 20px;
                                           height: 20px;
                                           opacity: 1;
                                           fill: currentcolor;
                                           --BaseIcon-color: #333333;
                                           margin-bottom: 0px;
-                                        ">
+                                        "
+                                      >
                                         <g clip-path="url(#clip0_124_2945)">
-                                          <path fill-rule="evenodd" clip-rule="evenodd"
-                                            d="M18.4697 4.46973L19.5303 5.53039L13.0597 11.9997L19.5303 18.4697L18.4697 19.5304L11.9997 13.0597L5.53033 19.5304L4.46967 18.4697L10.9397 11.9997L4.46967 5.53039L5.53033 4.46973L11.9997 10.9397L18.4697 4.46973Z">
-                                          </path>
+                                          <path
+                                            fill-rule="evenodd"
+                                            clip-rule="evenodd"
+                                            d="M18.4697 4.46973L19.5303 5.53039L13.0597 11.9997L19.5303 18.4697L18.4697 19.5304L11.9997 13.0597L5.53033 19.5304L4.46967 18.4697L10.9397 11.9997L4.46967 5.53039L5.53033 4.46973L11.9997 10.9397L18.4697 4.46973Z"
+                                          ></path>
                                         </g>
                                         <defs>
                                           <clipPath id="clip0_124_2945">
@@ -595,7 +993,10 @@
                                           </clipPath>
                                         </defs>
                                       </svg>
-                                      <div data-v-524f63ea="" class="inline-flex items-center">
+                                      <div
+                                        data-v-524f63ea=""
+                                        class="inline-flex items-center"
+                                      >
                                         <!---->
                                       </div>
                                     </button>
@@ -603,56 +1004,113 @@
                                 </div>
                               </div>
 
-                              <hr data-v-6ef4cf18="" data-v-8cd67775="" class="BaseDivider last:hidden"
-                                style="--border-color: #f5f5f5" />
+                              <hr
+                                data-v-6ef4cf18=""
+                                data-v-8cd67775=""
+                                class="BaseDivider last:hidden"
+                                style="--border-color: #f5f5f5"
+                              />
                             </div>
 
-                            <!-- 주문 요청 사항 -->
+                            <!-- 주문 요청  -->
                             <div data-v-8cd67775="" class="pt-[4px] pb-[16px]">
-                              <div data-v-be77401d=""
+                              <!-- display none or block -->
+                              <div
+                                v-if="!isEditing[product.productIdx]"
+                                @click="toggleEdit(product.productIdx)"
+                                data-v-be77401d=""
                                 class="BaseTextarea BaseTextarea__type--outline BaseTextarea__fixedSize--small flex-auto"
                                 style="
                                   --BaseTextarea-min-height: 0;
                                   --BaseTextarea-max-height: 0;
                                   --BaseTextarea-radius: 2;
-                                  display: none
-                                ">
-                                <div data-v-e2593c18="" data-v-be77401d="" class="BaseLabelText BaseTextarea__label"
-                                  style="display: ">
-                                  <span data-v-e2593c18="" class="BaseLabelText__text"></span><!---->
+                                "
+                              >
+                                <div
+                                  data-v-e2593c18=""
+                                  data-v-be77401d=""
+                                  class="BaseLabelText BaseTextarea__label"
+                                  style="display: "
+                                >
+                                  <span
+                                    data-v-e2593c18=""
+                                    class="BaseLabelText__text"
+                                  ></span
+                                  ><!---->
                                 </div>
-                                <textarea data-v-be77401d="" placeholder="주문 요청사항을 500자 내로 입력해주세요." readonly=""
-                                  class="BaseTextarea__textarea"></textarea><!---->
+                                <textarea
+                                  v-model="newOrderMessage[product.productIdx]"
+                                  data-v-be77401d=""
+                                  placeholder="주문 요청사항을 500자 내로 입력해주세요."
+                                  readonly=""
+                                  class="BaseTextarea__textarea"
+                                ></textarea
+                                ><!---->
                               </div>
-                              <div class="flex" style="display: ">
-                                <div data-v-be77401d=""
+
+                              <!-- edit div -->
+                              <div v-else class="flex">
+                                <div
+                                  data-v-be77401d=""
                                   class="BaseTextarea BaseTextarea__type--outline BaseTextarea__fixedSize--small flex-auto"
                                   style="
                                     --BaseTextarea-min-height: 0;
                                     --BaseTextarea-max-height: 0;
                                     --BaseTextarea-radius: 2;
-                                  ">
-                                  <div data-v-e2593c18="" data-v-be77401d="" class="BaseLabelText BaseTextarea__label"
-                                    style="display: none">
-                                    <span data-v-e2593c18="" class="BaseLabelText__text"></span><!---->
+                                  "
+                                >
+                                  <div
+                                    data-v-e2593c18=""
+                                    data-v-be77401d=""
+                                    class="BaseLabelText BaseTextarea__label"
+                                    style="display: none"
+                                  >
+                                    <span
+                                      data-v-e2593c18=""
+                                      class="BaseLabelText__text"
+                                    ></span
+                                    ><!---->
                                   </div>
-                                  <textarea data-v-be77401d="" placeholder="주문 요청사항을 500자 내로 입력해주세요." maxlength="500"
-                                    class="BaseTextarea__textarea"></textarea>
-                                  <div data-v-be77401d="" class="BaseTextarea__assistiveArea">
-                                    <div data-v-86c06fc2="" data-v-be77401d=""
-                                      class="BaseTextHelper BaseTextHelper--default">
+                                  <textarea
+                                    v-model="
+                                      newOrderMessage[product.productIdx]
+                                    "
+                                    data-v-be77401d=""
+                                    placeholder="주문 요청사항을 500자 내로 입력해주세요."
+                                    maxlength="500"
+                                    class="BaseTextarea__textarea"
+                                  ></textarea>
+                                  <div
+                                    data-v-be77401d=""
+                                    class="BaseTextarea__assistiveArea"
+                                  >
+                                    <div
+                                      data-v-86c06fc2=""
+                                      data-v-be77401d=""
+                                      class="BaseTextHelper BaseTextHelper--default"
+                                    >
                                       <!---->
-                                      <div data-v-86c06fc2="" class="inline-flex items-center">
+                                      <div
+                                        data-v-86c06fc2=""
+                                        class="inline-flex items-center"
+                                      >
                                         입력 후 저장버튼을 눌러주세요
                                       </div>
                                     </div>
-                                    <div data-v-612abd8a="" data-v-be77401d=""
-                                      class="BaseTextCounter BaseTextCounter--default">
+                                    <div
+                                      data-v-612abd8a=""
+                                      data-v-be77401d=""
+                                      class="BaseTextCounter BaseTextCounter--default"
+                                    >
                                       <span data-v-612abd8a="">0/500</span>
                                     </div>
                                   </div>
                                 </div>
-                                <button data-v-524f63ea="" data-v-7940d6dd="" type="outline"
+                                <button
+                                  @click="saveOrderMessage(product.productIdx)"
+                                  data-v-524f63ea=""
+                                  data-v-7940d6dd=""
+                                  type="outline"
                                   class="CoreButton CoreButton--block BaseButtonRectangle body1-bold-small BaseButtonRectangle__outline ml-[8px]"
                                   style="
                                     background-color: rgb(255, 255, 255);
@@ -662,17 +1120,22 @@
                                     flex-direction: row;
                                     --core-button-padding-x: 16;
                                     --button-rectangle-border-color: #ef7014;
-                                  ">
+                                  "
+                                >
                                   <!----><!---->
-                                  <div data-v-524f63ea="" class="inline-flex items-center">
-                                    <span data-v-524f63ea="" class="CoreButton__text">저장</span>
+                                  <div
+                                    data-v-524f63ea=""
+                                    class="inline-flex items-center"
+                                  >
+                                    <span
+                                      data-v-524f63ea=""
+                                      class="CoreButton__text"
+                                      >저장</span
+                                    >
                                   </div>
                                 </button>
-
                               </div>
                             </div>
-
-
 
                             <div data-v-8cd67775="" class="w-full">
                               <div></div>
@@ -685,21 +1148,39 @@
 
                     <!-- 하단 공방 별 가격 -->
                     <div data-v-db78b45c="">
-                      <hr data-v-6ef4cf18="" class="BaseDivider" style="--border-color: #f5f5f5" />
-                      <div class="grid grid-flow-col gap-x-[1px] body3-regular-small py-[16px] grid-cols-2">
-                        <div class="flex items-center flex-col h-full border-r-[1px] border-[#f5f5f5]">
+                      <hr
+                        data-v-6ef4cf18=""
+                        class="BaseDivider"
+                        style="--border-color: #f5f5f5"
+                      />
+                      <div
+                        class="grid grid-flow-col gap-x-[1px] body3-regular-small py-[16px] grid-cols-2"
+                      >
+                        <div
+                          class="flex items-center flex-col h-full border-r-[1px] border-[#f5f5f5]"
+                        >
                           <div class="gray-666--text mb-[8px]">작품 금액</div>
                           <div class="body1-bold-small">
-                            {{ atelierTotals[atelier.atelierIdx]?.totalPrice || 0 }}원
+                            {{
+                              atelierTotals[atelier.atelierIdx]?.totalPrice ||
+                              0
+                            }}원
                           </div>
                           <div class="flex mt-[2px]">
-                            <div data-v-a1957620=""
-                              class="BaseDecorateText transform-gpu whitespace-pre inline mr-[4px] last:mr-0">
-                              <span data-v-a1957620="" class="DecorateText DecorateText--bold" style="
+                            <div
+                              data-v-a1957620=""
+                              class="BaseDecorateText transform-gpu whitespace-pre inline mr-[4px] last:mr-0"
+                            >
+                              <span
+                                data-v-a1957620=""
+                                class="DecorateText DecorateText--bold"
+                                style="
                                   font-size: 10px;
                                   color: rgb(255, 75, 80);
                                   background-color: inherit;
-                                ">즉시할인가</span>
+                                "
+                                >즉시할인가</span
+                              >
                             </div>
                           </div>
                         </div>
@@ -707,29 +1188,48 @@
                         <div class="flex items-center flex-col h-full">
                           <div class="gray-666--text mb-[8px]">주문 금액</div>
                           <div class="body1-bold-small">
-                            {{ atelierTotals[atelier.atelierIdx]?.totalPrice || 0 }}원
+                            {{
+                              atelierTotals[atelier.atelierIdx]?.totalPrice ||
+                              0
+                            }}원
                           </div>
                         </div>
                       </div>
                     </div>
                     <!-- 작가 더보기 -->
                     <div data-v-db78b45c="">
-                      <hr data-v-6ef4cf18="" class="BaseDivider" style="--border-color: #f5f5f5" />
-                      <div class="w-full h-[46px] flex items-center justify-center cursor-pointer">
-                        <div data-v-a1957620=""
-                          class="BaseDecorateText transform-gpu whitespace-pre inline inline-flex">
-                          <span data-v-a1957620="" class="DecorateText DecorateText--bold" style="
+                      <hr
+                        data-v-6ef4cf18=""
+                        class="BaseDivider"
+                        style="--border-color: #f5f5f5"
+                      />
+                      <div
+                        class="w-full h-[46px] flex items-center justify-center cursor-pointer"
+                      >
+                        <div
+                          data-v-a1957620=""
+                          class="BaseDecorateText transform-gpu whitespace-pre inline inline-flex"
+                        >
+                          <span
+                            data-v-a1957620=""
+                            class="DecorateText DecorateText--bold"
+                            style="
                               font-size: 12px;
                               color: rgb(80, 95, 205);
                               background-color: inherit;
-                            ">작가님 작품 더보기</span>
+                            "
+                            >작가님 작품 더보기</span
+                          >
                         </div>
                       </div>
                     </div>
                   </div>
                   <div data-v-db78b45c="" class="CartArtist__footer">
                     <div data-v-db78b45c="" class="CartArtist__footerInner">
-                      <div data-v-db78b45c="" class="CartArtist__footerInnerBorder"></div>
+                      <div
+                        data-v-db78b45c=""
+                        class="CartArtist__footerInnerBorder"
+                      ></div>
                     </div>
                   </div>
                 </div>
@@ -737,16 +1237,37 @@
 
               <!-- 오른쪽 가격 사이드바  -->
               <div data-v-a5290452="" class="w-[400px] ml-[30px] relative">
-                <div data-v-adaf8eae="" data-v-a5290452="" class="CartPriceInfo">
-                  <div data-v-adaf8eae=""
-                    class="border border-[#e1e1e1] rounded-[12px] pt-[10px] pb-[20px] px-[24px] white--background">
-                    <div data-v-adaf8eae="" class="subtitle2-bold-small my-[14px]">
+                <div
+                  data-v-adaf8eae=""
+                  data-v-a5290452=""
+                  class="CartPriceInfo"
+                >
+                  <div
+                    data-v-adaf8eae=""
+                    class="border border-[#e1e1e1] rounded-[12px] pt-[10px] pb-[20px] px-[24px] white--background"
+                  >
+                    <div
+                      data-v-adaf8eae=""
+                      class="subtitle2-bold-small my-[14px]"
+                    >
                       주문 예상 금액
                     </div>
-                    <hr data-v-6ef4cf18="" data-v-adaf8eae="" class="BaseDivider" style="--border-color: #333333" />
-                    <div data-v-936440ee="" data-v-adaf8eae="" class="PriceInfo">
+                    <hr
+                      data-v-6ef4cf18=""
+                      data-v-adaf8eae=""
+                      class="BaseDivider"
+                      style="--border-color: #333333"
+                    />
+                    <div
+                      data-v-936440ee=""
+                      data-v-adaf8eae=""
+                      class="PriceInfo"
+                    >
                       <div data-v-936440ee="" class="py-[20px]">
-                        <div data-v-936440ee="" class="PriceInfo__item mb-[12px]">
+                        <div
+                          data-v-936440ee=""
+                          class="PriceInfo__item mb-[12px]"
+                        >
                           <div data-v-936440ee="">총 작품금액</div>
                           <div data-v-936440ee="" class="subtitle3_bold_small">
                             {{ totalPrice }}원
@@ -754,24 +1275,54 @@
                         </div>
                         <!----><!----><!----><!---->
 
-                        <div data-v-936440ee="" class="PriceInfo__item mb-[16px] last:mb-0 !items-start">
+                        <div
+                          data-v-936440ee=""
+                          class="PriceInfo__item mb-[16px] last:mb-0 !items-start"
+                        >
                           <div data-v-936440ee="">배송비</div>
-                          <div data-v-936440ee="" class="flex flex-col items-end justify-center">
-                            <div data-v-936440ee="" class="flex items-center justify-end">
-                              <div data-v-a1957620="" data-v-936440ee=""
-                                class="BaseDecorateText transform-gpu whitespace-pre inline mr-[4px] last:mr-0">
-                                <span data-v-a1957620="" class="DecorateText" style="
+                          <div
+                            data-v-936440ee=""
+                            class="flex flex-col items-end justify-center"
+                          >
+                            <div
+                              data-v-936440ee=""
+                              class="flex items-center justify-end"
+                            >
+                              <div
+                                data-v-a1957620=""
+                                data-v-936440ee=""
+                                class="BaseDecorateText transform-gpu whitespace-pre inline mr-[4px] last:mr-0"
+                              >
+                                <span
+                                  data-v-a1957620=""
+                                  class="DecorateText"
+                                  style="
                                     font-size: 12px;
                                     color: rgb(51, 51, 51);
                                     background-color: inherit;
-                                  ">CGB는 전 작품</span>
+                                  "
+                                  >CGB는 전 작품</span
+                                >
                               </div>
-                              <div data-v-a1957620="" data-v-936440ee=""
-                                class="BaseDecorateText transform-gpu whitespace-pre inline mr-[4px] last:mr-0">
-                                <span data-v-a1957620="" class="DecorateText__badge"><!---->
-                                  <div data-v-c3bdd300="" data-v-a1957620="" class="BaseBadgeFreeShipping"
-                                    style="--icon-width: 48; --icon-height: 18">
-                                    <div data-v-c3bdd300="" class="BaseBadgeFreeShipping__icon"></div>
+                              <div
+                                data-v-a1957620=""
+                                data-v-936440ee=""
+                                class="BaseDecorateText transform-gpu whitespace-pre inline mr-[4px] last:mr-0"
+                              >
+                                <span
+                                  data-v-a1957620=""
+                                  class="DecorateText__badge"
+                                  ><!---->
+                                  <div
+                                    data-v-c3bdd300=""
+                                    data-v-a1957620=""
+                                    class="BaseBadgeFreeShipping"
+                                    style="--icon-width: 48; --icon-height: 18"
+                                  >
+                                    <div
+                                      data-v-c3bdd300=""
+                                      class="BaseBadgeFreeShipping__icon"
+                                    ></div>
                                   </div>
                                 </span>
                               </div>
@@ -780,41 +1331,76 @@
                           </div>
                         </div>
 
-                        <div data-v-62ba81fa="" data-v-936440ee=""
-                          class="BaseBannerMembership cursor-pointer mb-[16px] last:mb-0">
-                          <div data-v-27c9b08d="" data-v-62ba81fa="" class="BaseIconMembershipColor"
-                            style="--icon-width: 24; --icon-height: 24">
-                            <div data-v-27c9b08d="" class="BaseIconMembershipColor__icon"></div>
+                        <div
+                          data-v-62ba81fa=""
+                          data-v-936440ee=""
+                          class="BaseBannerMembership cursor-pointer mb-[16px] last:mb-0"
+                        >
+                          <div
+                            data-v-27c9b08d=""
+                            data-v-62ba81fa=""
+                            class="BaseIconMembershipColor"
+                            style="--icon-width: 24; --icon-height: 24"
+                          >
+                            <div
+                              data-v-27c9b08d=""
+                              class="BaseIconMembershipColor__icon"
+                            ></div>
                           </div>
-                          <div data-v-a1957620="" data-v-62ba81fa=""
-                            class="BaseDecorateText transform-gpu whitespace-pre inline flex ml-[4px]">
-                            <span data-v-a1957620="" class="DecorateText" style="
+                          <div
+                            data-v-a1957620=""
+                            data-v-62ba81fa=""
+                            class="BaseDecorateText transform-gpu whitespace-pre inline flex ml-[4px]"
+                          >
+                            <span
+                              data-v-a1957620=""
+                              class="DecorateText"
+                              style="
                                 font-size: 13px;
                                 color: rgb(255, 255, 255);
                                 background-color: inherit;
-                              ">멤버십 가입시
+                              "
+                              >멤버십 가입시
                             </span>
                           </div>
-                          <div data-v-a1957620="" data-v-62ba81fa=""
-                            class="BaseDecorateText transform-gpu whitespace-pre inline flex ml-[4px]">
-                            <span data-v-a1957620="" class="DecorateText DecorateText--bold" style="
+                          <div
+                            data-v-a1957620=""
+                            data-v-62ba81fa=""
+                            class="BaseDecorateText transform-gpu whitespace-pre inline flex ml-[4px]"
+                          >
+                            <span
+                              data-v-a1957620=""
+                              class="DecorateText DecorateText--bold"
+                              style="
                                 font-size: 13px;
                                 color: rgb(255, 255, 255);
                                 background-color: inherit;
-                              ">4천원 쿠폰 + 5% 추가할인</span>
+                              "
+                              >4천원 쿠폰 + 5% 추가할인</span
+                            >
                           </div>
-                          <svg data-v-6d2bd019="" data-v-62ba81fa="" width="24" height="24" viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg" class="BaseIcon" style="
+                          <svg
+                            data-v-6d2bd019=""
+                            data-v-62ba81fa=""
+                            width="24"
+                            height="24"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                            class="BaseIcon"
+                            style="
                               width: 20px;
                               height: 20px;
                               opacity: 1;
                               fill: currentcolor;
                               --BaseIcon-color: #ffffff;
-                            ">
+                            "
+                          >
                             <g clip-path="url(#clip0_124_2947)">
-                              <path fill-rule="evenodd" clip-rule="evenodd"
-                                d="M9.53039 5.46973L15.5304 11.4697C15.7967 11.736 15.8209 12.1527 15.603 12.4463L15.5304 12.5304L9.53039 18.5304L8.46973 17.4697L13.9391 12.0001L8.46973 6.53039L9.53039 5.46973Z">
-                              </path>
+                              <path
+                                fill-rule="evenodd"
+                                clip-rule="evenodd"
+                                d="M9.53039 5.46973L15.5304 11.4697C15.7967 11.736 15.8209 12.1527 15.603 12.4463L15.5304 12.5304L9.53039 18.5304L8.46973 17.4697L13.9391 12.0001L8.46973 6.53039L9.53039 5.46973Z"
+                              ></path>
                             </g>
                             <defs>
                               <clipPath id="clip0_124_2947">
@@ -824,12 +1410,20 @@
                           </svg>
                         </div>
                       </div>
-                      <hr data-v-6ef4cf18="" data-v-936440ee="" class="BaseDivider" style="--border-color: #f5f5f5" />
+                      <hr
+                        data-v-6ef4cf18=""
+                        data-v-936440ee=""
+                        class="BaseDivider"
+                        style="--border-color: #f5f5f5"
+                      />
                       <div data-v-936440ee="" class="PriceInfo__item py-[16px]">
                         <div data-v-936440ee="" class="subtitle3-bold-small">
                           총 {{ totalQuantity }}건 주문금액
                         </div>
-                        <div data-v-936440ee="" class="flex flex-col items-end justify-center">
+                        <div
+                          data-v-936440ee=""
+                          class="flex flex-col items-end justify-center"
+                        >
                           <div data-v-936440ee="" class="subtitle1-bold-small">
                             {{ totalPrice }}원
                           </div>
@@ -839,7 +1433,10 @@
                     </div>
                     <!---->
                     <div data-v-adaf8eae="" class="flex justify-between w-full">
-                      <button data-v-524f63ea="" data-v-7940d6dd="" type="outline"
+                      <button
+                        data-v-524f63ea=""
+                        data-v-7940d6dd=""
+                        type="outline"
                         class="CoreButton BaseButtonRectangle subtitle3-bold-small BaseButtonRectangle__outline w-[112px] mr-[8px]"
                         style="
                           background-color: rgb(255, 255, 255);
@@ -848,13 +1445,24 @@
                           flex-direction: row;
                           --core-button-padding-x: 16;
                           --button-rectangle-border-color: #acacac;
-                        ">
+                        "
+                      >
                         <!----><!---->
-                        <div data-v-524f63ea="" class="inline-flex items-center">
-                          <span data-v-524f63ea="" class="CoreButton__text">선물하기</span>
-                        </div>
-                      </button><button @click="next" to="/login" :disabled="selectedItems.length === 0"
-                        data-v-524f63ea="" data-v-7940d6dd="" type="fill"
+                        <div
+                          data-v-524f63ea=""
+                          class="inline-flex items-center"
+                        >
+                          <span data-v-524f63ea="" class="CoreButton__text"
+                            >선물하기</span
+                          >
+                        </div></button
+                      ><button
+                        @click="next"
+                        to="/login"
+                        :disabled="selectedItems.length === 0"
+                        data-v-524f63ea=""
+                        data-v-7940d6dd=""
+                        type="fill"
                         class="CoreButton BaseButtonRectangle subtitle3-bold-small BaseButtonRectangle__fill grow"
                         style="
                           background-color: rgb(239, 112, 20);
@@ -862,10 +1470,16 @@
                           height: 44px;
                           flex-direction: row;
                           --core-button-padding-x: 16;
-                        ">
+                        "
+                      >
                         <!----><!---->
-                        <div data-v-524f63ea="" class="inline-flex items-center">
-                          <span data-v-524f63ea="" class="CoreButton__text">{{ totalQuantity }}건 주문하기</span>
+                        <div
+                          data-v-524f63ea=""
+                          class="inline-flex items-center"
+                        >
+                          <span data-v-524f63ea="" class="CoreButton__text"
+                            >{{ totalQuantity }}건 주문하기</span
+                          >
                         </div>
                       </button>
                     </div>
@@ -882,10 +1496,20 @@
         </div>
       </div>
       <!----><!---->
-      <div class="BaseSnackbar__fadeOut !hidden BaseSnackbar TheSnackbar" data-v-4e58ad83="" data-v-ac6313c6="">
-        <div class="BaseSnackbar__wrapper boxShadow__x-large py-[8px] pl-[12px] pr-[12px]" data-v-ac6313c6="">
+      <div
+        class="BaseSnackbar__fadeOut !hidden BaseSnackbar TheSnackbar"
+        data-v-4e58ad83=""
+        data-v-ac6313c6=""
+      >
+        <div
+          class="BaseSnackbar__wrapper boxShadow__x-large py-[8px] pl-[12px] pr-[12px]"
+          data-v-ac6313c6=""
+        >
           <!---->
-          <div class="body1-regular-medium line-clamp-2 whitespace-pre-line" data-v-ac6313c6=""></div>
+          <div
+            class="body1-regular-medium line-clamp-2 whitespace-pre-line"
+            data-v-ac6313c6=""
+          ></div>
           <!---->
         </div>
       </div>
@@ -894,7 +1518,7 @@
   </div>
 </template>
 <script setup>
-import { onMounted, computed } from 'vue';
+import { onMounted, computed, ref, defineProps } from 'vue';
 import { useCartStore } from '@/stores/useCartStore';
 import { storeToRefs } from 'pinia';
 import { useRouter } from 'vue-router';
@@ -904,8 +1528,31 @@ const cartStore = useCartStore();
 const { selectedItems, totalPrice, totalQuantity, loading, atelierTotals } =
   storeToRefs(cartStore);
 
-onMounted(() => {
-  cartStore.fetchCartList();
+const isEditing = ref({});
+const newOrderMessage = ref({});
+
+//장바구니, 선물, 바로구매 구분
+const props = defineProps({
+  pageType: String,
+  encryptedCartIdx: String,
+});
+
+onMounted(async () => {
+  if (props.pageType === 'gift') {
+    await cartStore.purchaseCartList(props.encryptedCartIdx);
+  } else if (props.pageType === 'order') {
+    await cartStore.purchaseCartList(props.encryptedCartIdx);
+  } else {
+    await cartStore.fetchCartList();
+  }
+
+  await cartStore.fetchCartList();
+  cartStore.cartList.forEach((atelier) => {
+    atelier.productList.forEach((product) => {
+      newOrderMessage.value[product.productIdx] =
+        product.optionList[0].orderMessage || '';
+    });
+  });
 });
 
 const cartList = computed(() => cartStore.cartList);
@@ -963,11 +1610,46 @@ const updateQuantity = (cartIdx, count) => {
   cartStore.updateQuantity(cartIdx, count);
 };
 
+const toggleEdit = (productIdx) => {
+  isEditing.value[productIdx] = !isEditing.value[productIdx];
+  const product = cartStore.cartList
+    .flatMap((atelier) => atelier.productList)
+    .find((p) => p.productIdx === productIdx);
+
+  if (product) {
+    newOrderMessage.value[productIdx] =
+      product.optionList[0].orderMessage || '';
+  }
+};
+
+const saveOrderMessage = async (productIdx) => {
+  const product = cartStore.cartList
+    .flatMap((atelier) => atelier.productList)
+    .find((p) => p.productIdx === productIdx);
+
+  if (product) {
+    const cartIdxList = product.optionList.map((option) => option.cartIdx);
+
+    try {
+      await cartStore.saveOrderMessage(
+        cartIdxList,
+        newOrderMessage.value[productIdx]
+      );
+      isEditing.value[productIdx] = false;
+    } catch (error) {
+      console.error('Error saving order message:', error);
+    }
+  } else {
+    console.error('not found productIdx:', productIdx);
+  }
+};
+
 // 결제 진행
 const next = () => {
-  cartStore.next();
+  const nextData = cartStore.next();
   router.push({
     path: '/next-page',
+    state: nextData,
   });
 };
 

--- a/frontend/src/components/order/CartComponent.vue
+++ b/frontend/src/components/order/CartComponent.vue
@@ -1518,10 +1518,10 @@
   </div>
 </template>
 <script setup>
-import { onMounted, computed, ref, defineProps } from 'vue';
-import { useCartStore } from '@/stores/useCartStore';
-import { storeToRefs } from 'pinia';
-import { useRouter } from 'vue-router';
+import { onMounted, computed, ref, defineProps } from "vue";
+import { useCartStore } from "@/stores/useCartStore";
+import { storeToRefs } from "pinia";
+import { useRouter } from "vue-router";
 
 const router = useRouter();
 const cartStore = useCartStore();
@@ -1538,9 +1538,9 @@ const props = defineProps({
 });
 
 onMounted(async () => {
-  if (props.pageType === 'gift') {
+  if (props.pageType === "gift") {
     await cartStore.purchaseCartList(props.encryptedCartIdx);
-  } else if (props.pageType === 'order') {
+  } else if (props.pageType === "order") {
     await cartStore.purchaseCartList(props.encryptedCartIdx);
   } else {
     await cartStore.fetchCartList();
@@ -1550,7 +1550,7 @@ onMounted(async () => {
   cartStore.cartList.forEach((atelier) => {
     atelier.productList.forEach((product) => {
       newOrderMessage.value[product.productIdx] =
-        product.optionList[0].orderMessage || '';
+        product.optionList[0].orderMessage || "";
     });
   });
 });
@@ -1618,7 +1618,7 @@ const toggleEdit = (productIdx) => {
 
   if (product) {
     newOrderMessage.value[productIdx] =
-      product.optionList[0].orderMessage || '';
+      product.optionList[0].orderMessage || "";
   }
 };
 
@@ -1637,10 +1637,10 @@ const saveOrderMessage = async (productIdx) => {
       );
       isEditing.value[productIdx] = false;
     } catch (error) {
-      console.error('Error saving order message:', error);
+      console.error("Error saving order message:", error);
     }
   } else {
-    console.error('not found productIdx:', productIdx);
+    console.error("not found productIdx:", productIdx);
   }
 };
 
@@ -1648,7 +1648,7 @@ const saveOrderMessage = async (productIdx) => {
 const next = () => {
   const nextData = cartStore.next();
   router.push({
-    path: '/next-page',
+    path: "/next-page",
     state: nextData,
   });
 };
@@ -1656,14 +1656,14 @@ const next = () => {
 // 체크박스 라벨 클래스
 const getCheckboxLabelClass = (isChecked) => {
   return isChecked
-    ? 'BaseCheckbox BaseCheckbox__size--small BaseCheckbox__verticalAlign--center BaseCheckbox__state--checked !w-auto inline-flex'
-    : 'BaseCheckbox BaseCheckbox__size--small BaseCheckbox__verticalAlign--center BaseCheckbox__state--unChecked !w-auto inline-flex';
+    ? "BaseCheckbox BaseCheckbox__size--small BaseCheckbox__verticalAlign--center BaseCheckbox__state--checked !w-auto inline-flex"
+    : "BaseCheckbox BaseCheckbox__size--small BaseCheckbox__verticalAlign--center BaseCheckbox__state--unChecked !w-auto inline-flex";
 };
 
 // 체크박스 SVG 스타일
 const getCheckboxSvgStyle = (isChecked) => {
   return isChecked
-    ? 'width: 24px; height: 24px; opacity: 1; fill: currentcolor; --BaseIcon-color: #ffffff;'
-    : 'width: 24px; height: 24px; opacity: 1; fill: currentcolor; --BaseIcon-color: #d9d9d9;';
+    ? "width: 24px; height: 24px; opacity: 1; fill: currentcolor; --BaseIcon-color: #ffffff;"
+    : "width: 24px; height: 24px; opacity: 1; fill: currentcolor; --BaseIcon-color: #d9d9d9;";
 };
 </script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,6 +1,6 @@
 import { createRouter, createWebHistory } from "vue-router";
-import LoginPage from "@/pages/member/LoginPage.vue"
-import SignupPage from "@/pages/member/SignupPage.vue"
+import LoginPage from '@/pages/member/LoginPage.vue';
+import SignupPage from '@/pages/member/SingupPage.vue';
 import DeliveryComponent from '@/components/member/DeliveryComponent.vue';
 import MemberInfoPage from "@/pages/member/MemberInfoPage.vue";
 import CartComponent from '@/components/order/CartComponent.vue';
@@ -16,27 +16,90 @@ import AskCommentComponent from "@/components/AskCommentComponent.vue";
 import EmailFindPage from "@/pages/member/MemberEmailFindPage";
 import GradeComponent from '@/components/mypage/GradeComponent.vue';
 import LoginCallBackComponent from "@/components/member/LoginCallBackComponent";
+import { useMemberStore } from '@/stores/useMemberStore';
+
+const requireLogin = async (to, from, next) => {
+  const memberStore = useMemberStore();
+
+  // await memberStore.verify(); // TODO
+
+  if (memberStore.isLogined) {
+    return next();
+  }
+
+  next({
+    path: '/login',
+    query: { redirect: to.fullPath },
+  });
+};
 
 const router = createRouter({
-    history: createWebHistory(),
-    routes: [
+  history: createWebHistory(),
+  routes: [
+    {
+      path: '/mypage',
+      component: MyPage, // 고정
+      children: [
         {
-            path: '/mypage',
-            component: MyPage, // 고정
-            children: [
-                { path: 'favorite/likes', name: 'likes', component: MyFavoriteListComponent, props: { initialTab: 0 } },
-                { path: 'favorite/follow-artist', name: 'follow-artist', component: MyFavoriteListComponent, props: { initialTab: 1 } },
-                { path: 'favorite/recent-view', name: 'recent-view', component: MyFavoriteListComponent, props: { initialTab: 2 } },
-                { path: '/deliveryAddress', name: 'deliveryAddress', component: DeliveryComponent },
-                { path: '/grade', name: 'grade', component: GradeComponent },
-            ],
+          path: 'favorite/likes',
+          name: 'likes',
+          component: MyFavoriteListComponent,
+          props: { initialTab: 0 },
         },
+        {
+          path: 'favorite/follow-artist',
+          name: 'follow-artist',
+          component: MyFavoriteListComponent,
+          props: { initialTab: 1 },
+        },
+        {
+          path: 'favorite/recent-view',
+          name: 'recent-view',
+          component: MyFavoriteListComponent,
+          props: { initialTab: 2 },
+        },
+        {
+          path: '/deliveryAddress',
+          name: 'deliveryAddress',
+          component: DeliveryComponent,
+        },
+        { path: '/grade', name: 'grade', component: GradeComponent },
+      ],
+    },
 
         { path: "/main", component: MainPage },
 
-        { path: '/cart', component: CartComponent },
-        { path: '/order/payment', component: OrderPayment },
-        { path: '/present/payment', component: PresentPayment },
+    // 장바구니, 구매, 선물
+    {
+      path: '/cart',
+      name: 'Cart',
+      component: CartComponent,
+      beforeEnter: requireLogin,
+      props: { pageType: 'cart' },
+    },
+    {
+      path: '/cart/direct/:encryptedCartIdx',
+      name: 'OrderPage',
+      component: CartComponent,
+      beforeEnter: requireLogin,
+      props: (route) => ({
+        pageType: 'order',
+        encryptedCartIdx: route.params.encryptedCartIdx,
+      }),
+    },
+    {
+      path: '/cart/gift/:encryptedCartIdx',
+      name: 'GiftPage',
+      component: CartComponent,
+      beforeEnter: requireLogin,
+      props: (route) => ({
+        pageType: 'gift',
+        encryptedCartIdx: route.params.encryptedCartIdx,
+      }),
+    },
+
+    { path: '/order/payment', component: OrderPayment },
+    { path: '/present/payment', component: PresentPayment },
 
         {
             path: '/atelier', component: AtelierPage,

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,22 +1,22 @@
 import { createRouter, createWebHistory } from "vue-router";
-import LoginPage from '@/pages/member/LoginPage.vue';
-import SignupPage from '@/pages/member/SingupPage.vue';
-import DeliveryComponent from '@/components/member/DeliveryComponent.vue';
+import LoginPage from "@/pages/member/LoginPage.vue";
+import SignupPage from "@/pages/member/SignupPage.vue";
+import DeliveryComponent from "@/components/member/DeliveryComponent.vue";
 import MemberInfoPage from "@/pages/member/MemberInfoPage.vue";
-import CartComponent from '@/components/order/CartComponent.vue';
+import CartComponent from "@/components/order/CartComponent.vue";
 import MyFavoriteListComponent from "@/components/mypage/MyFavoriteListComponent.vue";
 import MyPage from "@/pages/mypage/MyPage.vue";
-import MainPage from '@/pages/MainPage'
-import OrderPayment from '@/pages/payment/OrderPaymentPage';
-import PresentPayment from '@/pages/payment/PresentPaymentPage';
-import AtelierPage from '@/pages/atelier/AtelierPage';
-import AtelierProducts from '@/components/atelier/AtelierProductListComponent';
-import AtelierProfile from '@/components/atelier/AtelierProfileComponent';
+import MainPage from "@/pages/MainPage";
+import OrderPayment from "@/pages/payment/OrderPaymentPage";
+import PresentPayment from "@/pages/payment/PresentPaymentPage";
+import AtelierPage from "@/pages/atelier/AtelierPage";
+import AtelierProducts from "@/components/atelier/AtelierProductListComponent";
+import AtelierProfile from "@/components/atelier/AtelierProfileComponent";
 import AskCommentComponent from "@/components/AskCommentComponent.vue";
 import EmailFindPage from "@/pages/member/MemberEmailFindPage";
-import GradeComponent from '@/components/mypage/GradeComponent.vue';
+import GradeComponent from "@/components/mypage/GradeComponent.vue";
 import LoginCallBackComponent from "@/components/member/LoginCallBackComponent";
-import { useMemberStore } from '@/stores/useMemberStore';
+import { useMemberStore } from "@/stores/useMemberStore";
 
 const requireLogin = async (to, from, next) => {
   const memberStore = useMemberStore();
@@ -28,7 +28,7 @@ const requireLogin = async (to, from, next) => {
   }
 
   next({
-    path: '/login',
+    path: "/login",
     query: { redirect: to.fullPath },
   });
 };
@@ -37,88 +37,88 @@ const router = createRouter({
   history: createWebHistory(),
   routes: [
     {
-      path: '/mypage',
+      path: "/mypage",
       component: MyPage, // 고정
       children: [
         {
-          path: 'favorite/likes',
-          name: 'likes',
+          path: "favorite/likes",
+          name: "likes",
           component: MyFavoriteListComponent,
           props: { initialTab: 0 },
         },
         {
-          path: 'favorite/follow-artist',
-          name: 'follow-artist',
+          path: "favorite/follow-artist",
+          name: "follow-artist",
           component: MyFavoriteListComponent,
           props: { initialTab: 1 },
         },
         {
-          path: 'favorite/recent-view',
-          name: 'recent-view',
+          path: "favorite/recent-view",
+          name: "recent-view",
           component: MyFavoriteListComponent,
           props: { initialTab: 2 },
         },
         {
-          path: '/deliveryAddress',
-          name: 'deliveryAddress',
+          path: "/deliveryAddress",
+          name: "deliveryAddress",
           component: DeliveryComponent,
         },
-        { path: '/grade', name: 'grade', component: GradeComponent },
+        { path: "/grade", name: "grade", component: GradeComponent },
       ],
     },
 
-        { path: "/main", component: MainPage },
+    { path: "/main", component: MainPage },
 
     // 장바구니, 구매, 선물
     {
-      path: '/cart',
-      name: 'Cart',
+      path: "/cart",
+      name: "Cart",
       component: CartComponent,
       beforeEnter: requireLogin,
-      props: { pageType: 'cart' },
+      props: { pageType: "cart" },
     },
     {
-      path: '/cart/direct/:encryptedCartIdx',
-      name: 'OrderPage',
+      path: "/cart/direct/:encryptedCartIdx",
+      name: "OrderPage",
       component: CartComponent,
       beforeEnter: requireLogin,
       props: (route) => ({
-        pageType: 'order',
+        pageType: "order",
         encryptedCartIdx: route.params.encryptedCartIdx,
       }),
     },
     {
-      path: '/cart/gift/:encryptedCartIdx',
-      name: 'GiftPage',
+      path: "/cart/gift/:encryptedCartIdx",
+      name: "GiftPage",
       component: CartComponent,
       beforeEnter: requireLogin,
       props: (route) => ({
-        pageType: 'gift',
+        pageType: "gift",
         encryptedCartIdx: route.params.encryptedCartIdx,
       }),
     },
 
-    { path: '/order/payment', component: OrderPayment },
-    { path: '/present/payment', component: PresentPayment },
+    { path: "/order/payment", component: OrderPayment },
+    { path: "/present/payment", component: PresentPayment },
 
-        {
-            path: '/atelier', component: AtelierPage,
-            children: [
-                { path: '', redirect: '/profile' },
-                { path: '/products', component: AtelierProducts },
-                { path: '/profile', component: AtelierProfile },
-            ]
-        },
-        { path: '/ask', component: AskCommentComponent },
+    {
+      path: "/atelier",
+      component: AtelierPage,
+      children: [
+        { path: "", redirect: "/profile" },
+        { path: "/products", component: AtelierProducts },
+        { path: "/profile", component: AtelierProfile },
+      ],
+    },
+    { path: "/ask", component: AskCommentComponent },
 
-        //member
-        { path: "/login", component: LoginPage },   // 로그인 페이지
-        { path: "/login-callback", component: LoginCallBackComponent },   // 소셜 로그인 콜백
-        { path: "/signup", component: SignupPage }, // 회원가입 페이지
-        { path: '/member/info', component: MemberInfoPage },    //회원 수정 페이지
-        { path: '/member/find', component: EmailFindPage },    //회원 찾기 페이지
-
-    ],
+    //member
+    { path: "/login", component: LoginPage }, // 로그인 페이지
+    { path: "/login-callback", component: LoginCallBackComponent }, // 소셜 로그인 콜백
+    { path: "/signup", component: SignupPage }, // 회원가입 페이지
+    { path: "/member/info", component: MemberInfoPage }, //회원 수정 페이지
+    { path: "/member/find", component: EmailFindPage }, //회원 찾기 페이지
+  ],
 });
 
 export default router;

--- a/frontend/src/stores/useCartStore.js
+++ b/frontend/src/stores/useCartStore.js
@@ -1,7 +1,7 @@
-import { defineStore } from 'pinia';
-import axios from 'axios';
+import { defineStore } from "pinia";
+import axios from "axios";
 
-export const useCartStore = defineStore('cart', {
+export const useCartStore = defineStore("cart", {
   state: () => ({
     cartList: [], // 장바구니 상품 리스트
     selectedItems: [], // 선택된 상품 리스트 (cartIdx, productIdx, atelierIdx 다)
@@ -15,11 +15,11 @@ export const useCartStore = defineStore('cart', {
     async fetchCartList() {
       try {
         this.loading = true;
-        const response = await axios.get('/api/cart');
+        const response = await axios.get("/api/cart");
         this.cartList = response.data.result.atelierList;
         this.updateSelectedItems();
       } catch (error) {
-        console.error('Error fetching cart list:', error);
+        console.error("Error fetching cart list:", error);
       } finally {
         this.loading = false;
       }
@@ -32,7 +32,7 @@ export const useCartStore = defineStore('cart', {
         this.cartList = response.data.result.atelierList;
         this.updateSelectedItems();
       } catch (error) {
-        console.error('Error fetching cart list:', error);
+        console.error("Error fetching cart list:", error);
       } finally {
         this.loading = false;
       }
@@ -177,7 +177,7 @@ export const useCartStore = defineStore('cart', {
         await this.fetchCartList();
         this.updateSelectedItems();
       } catch (error) {
-        console.error('Error updating quantity:', error);
+        console.error("Error updating quantity:", error);
       } finally {
         this.loading = false;
       }
@@ -201,7 +201,7 @@ export const useCartStore = defineStore('cart', {
         const response = await axios.post(`/api/cart/verify`, { productIdx });
         return response.data.isSuccess;
       } catch (error) {
-        console.error('Error verify Cart:', error);
+        console.error("Error verify Cart:", error);
         return false;
       } finally {
         this.loading = false;
@@ -211,14 +211,14 @@ export const useCartStore = defineStore('cart', {
     async saveOrderMessage(cartIdx, message) {
       try {
         this.loading = true;
-        await axios.patch('/api/cart/order-message', {
+        await axios.patch("/api/cart/order-message", {
           cartIdx: cartIdx,
           message: message,
         });
         await this.fetchCartList();
         this.updateSelectedItems();
       } catch (error) {
-        console.error('Error save orderMessage:', error);
+        console.error("Error save orderMessage:", error);
       } finally {
         this.loading = false;
       }

--- a/frontend/src/stores/useCartStore.js
+++ b/frontend/src/stores/useCartStore.js
@@ -25,6 +25,19 @@ export const useCartStore = defineStore('cart', {
       }
     },
 
+    async purchaseCartList(encrypt) {
+      try {
+        this.loading = true;
+        const response = await axios.get(`/api/cart/direct/${encrypt}`);
+        this.cartList = response.data.result.atelierList;
+        this.updateSelectedItems();
+      } catch (error) {
+        console.error('Error fetching cart list:', error);
+      } finally {
+        this.loading = false;
+      }
+    },
+
     // 선택된 아이템의 상태를 업데이트
     updateSelectedItems() {
       this.cartList.forEach((atelier) => {
@@ -190,6 +203,22 @@ export const useCartStore = defineStore('cart', {
       } catch (error) {
         console.error('Error verify Cart:', error);
         return false;
+      } finally {
+        this.loading = false;
+      }
+    },
+
+    async saveOrderMessage(cartIdx, message) {
+      try {
+        this.loading = true;
+        await axios.patch('/api/cart/order-message', {
+          cartIdx: cartIdx,
+          message: message,
+        });
+        await this.fetchCartList();
+        this.updateSelectedItems();
+      } catch (error) {
+        console.error('Error save orderMessage:', error);
       } finally {
         this.loading = false;
       }


### PR DESCRIPTION
## 📚이슈 번호

#138 

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->

1. 장바구니 컴포넌트 요청 메세지 추가
2. 바로 주문하기, 선물하기를 각각 index.js에 라우터 설정

<br><br>

## 💪작업 상세 내용

1. 장바구니 컴포넌트에 요청 메세지가 정상적으로 저장되도록 함
장바구니에서 요청 메세지를 작성하고 저장하면 해당 cartIdx에 요청 메세지가 저장됩니다.
그래서 A상품을 장바구니에 저장한 뒤,  새로 A상품을 바로 구매하기로 진입해도 각각 다른 요청 메세지를 저장할 수  있습니다.

![image](https://github.com/user-attachments/assets/d1d0fc71-2f9f-4212-8163-2319790fdd8a)


3. 장바구니와 바로 주문하기, 선물하기 router 설정

아직 상세페이지가 없어서 제대로 연결되는지 이후에 확인해봐야 하고, 쿼리에 대한 상세한 설명은
[[Feat] 바로 구매하기, 선물하기를 위한 cartIdx 리스트 암복호화](https://github.com/beyond-sw-camp/be06-fin-SYNergy-ComeGongBang/pull/194)
해당 링크에 있습니다.

같은 컴포넌트를 재사용하며 이를 위해 pageType을 prop로 넘겨 구분합니다. 

그냥 장바구니 조회 시 해당 코드로 조회
```
const response = await axios.get("/api/cart");
```
pageType이 order인 경우
```
const response = await axios.get(`/api/cart/direct/${encrypt}`);
```

아래는 index.js 라우터 설정입니다. 
```
    {
      path: "/cart",
      name: "Cart",
      component: CartComponent,
      beforeEnter: requireLogin,
      props: { pageType: "cart" },
    },
    {
      path: "/cart/direct/:encryptedCartIdx",
      name: "OrderPage",
      component: CartComponent,
      beforeEnter: requireLogin,
      props: (route) => ({
        pageType: "order",
        encryptedCartIdx: route.params.encryptedCartIdx,
      }),
    },
    {
      path: "/cart/gift/:encryptedCartIdx",
      name: "GiftPage",
      component: CartComponent,
      beforeEnter: requireLogin,
      props: (route) => ({
        pageType: "gift",
        encryptedCartIdx: route.params.encryptedCartIdx,
      }),
    },
```

<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->

<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
