### PR TITLE
[Feat] 작가 정보 조회 , 화원-팔로우 기능 구현

### DIFF
--- a/backend/src/main/java/com/synergy/backend/domain/atelier/controller/AtelierController.java
+++ b/backend/src/main/java/com/synergy/backend/domain/atelier/controller/AtelierController.java
@@ -1,12 +1,14 @@
 package com.synergy.backend.domain.atelier.controller;
 
-import com.synergy.backend.domain.atelier.model.entity.Atelier;
+import com.synergy.backend.domain.atelier.model.response.AtelierProfileInfoRes;
 import com.synergy.backend.domain.atelier.service.AtelierService;
 import com.synergy.backend.domain.product.model.response.ProductListRes;
 import com.synergy.backend.global.common.BaseResponse;
 import com.synergy.backend.global.exception.BaseException;
-import java.util.*;
+import com.synergy.backend.global.security.CustomUserDetails;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,6 +22,20 @@ public class AtelierController {
     @GetMapping("/products")
     public BaseResponse<List<ProductListRes>> atelierProductList(Long idx) throws BaseException {
         List<ProductListRes> result = atelierService.atelierProductList(idx);
+
+        return new BaseResponse<>(result);
+    }
+
+    @GetMapping("/info")
+    public BaseResponse<AtelierProfileInfoRes> atelierProfileInfo(
+            Long atelierIdx, @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
+
+        Long memberIdx = null;
+        if(customUserDetails != null){
+            memberIdx = customUserDetails.getIdx();
+        }
+
+        AtelierProfileInfoRes result = atelierService.getAtelierProfileInfo(atelierIdx,memberIdx);
 
         return new BaseResponse<>(result);
     }

--- a/backend/src/main/java/com/synergy/backend/domain/atelier/model/entity/Atelier.java
+++ b/backend/src/main/java/com/synergy/backend/domain/atelier/model/entity/Atelier.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
@@ -19,13 +20,34 @@ public class Atelier extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long idx;
 
+    private String profileImage;
     private String name;
+    @Setter
+    private Double averageScore;
+    @Setter
+    private int havingProductsReviewCount;
+    @Setter
+    private int havingProductsLikeCount;
+
+    private Integer havingFollowerCount;
     private String oneLineDescription;
+
+
+
+    // 공방 주소 (보류)
     private String address;
     private String addressDetail;
-    private Integer follower;
+
+    // 공방 프로필 (보류)
     private String title;
     private String content;
-    private String profileImage;
+
+    public void increaseFollowCount(){
+        this.havingFollowerCount++;
+    }
+
+    public void decreaseFollowCount(){
+        this.havingFollowerCount--;
+    }
 
 }

--- a/backend/src/main/java/com/synergy/backend/domain/atelier/model/response/AtelierProfileInfoRes.java
+++ b/backend/src/main/java/com/synergy/backend/domain/atelier/model/response/AtelierProfileInfoRes.java
@@ -1,0 +1,29 @@
+package com.synergy.backend.domain.atelier.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AtelierProfileInfoRes {
+
+    // 공방 idx
+    private Long atelierIdx;
+    // 공방 프로필 이미지
+    private String atelierProfileImage;
+    // 공방 이름
+    private String atelierName;
+    // 공방 평점
+    private double atelierAverageScore;
+    //공방 상품 리뷰 개수
+    private int havingProductsReviewCount;
+    // 공방이 파는 모든상품 찜 수
+    private int havingProductsLikeCount;
+    // 공방 팔로워 수
+    private int havingFollowerCount;
+    // 공방 한줄 소개글
+    private String oneLineDescription;
+    // 회원-공방 팔로우 여부
+    private boolean memberIsFollow;
+
+}

--- a/backend/src/main/java/com/synergy/backend/domain/atelier/service/AtelierService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/atelier/service/AtelierService.java
@@ -1,7 +1,12 @@
 package com.synergy.backend.domain.atelier.service;
 
 import com.synergy.backend.domain.atelier.model.entity.Atelier;
+import com.synergy.backend.domain.atelier.model.response.AtelierProfileInfoRes;
 import com.synergy.backend.domain.atelier.repository.AtelierRepository;
+import com.synergy.backend.domain.follow.repository.FollowRepository;
+import com.synergy.backend.domain.follow.service.FollowService;
+import com.synergy.backend.domain.member.model.entity.Member;
+import com.synergy.backend.domain.member.repository.MemberRepository;
 import com.synergy.backend.domain.product.model.entity.Product;
 import com.synergy.backend.domain.product.model.response.ProductListRes;
 import com.synergy.backend.domain.product.repository.ProductRepository;
@@ -17,6 +22,8 @@ import org.springframework.stereotype.Service;
 public class AtelierService {
     private final AtelierRepository atelierRepository;
     private final ProductRepository productRepository;
+    private final MemberRepository memberRepository;
+    private final FollowService followService;
 
     public List<ProductListRes> atelierProductList(Long idx) throws BaseException {
         Atelier atelier = atelierRepository.findById(idx).orElseThrow(
@@ -37,6 +44,32 @@ public class AtelierService {
                     .category_name(result.getCategory().getCategoryName()).build());
         }
 
-        return  atelierProducts;
+        return atelierProducts;
+    }
+
+    public AtelierProfileInfoRes getAtelierProfileInfo(Long atelierIdx, Long memberIdx) throws BaseException {
+        Atelier atelier = atelierRepository.findById(atelierIdx).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.NOT_FOUND_ATELIER));
+
+        // 회원 - 공방 팔로우 여부
+        boolean memberIsFollow = false;
+        if (memberIdx != null) {
+            Member member = memberRepository.findById(memberIdx).get();
+            memberIsFollow = followService.isFollow(member,atelier);
+        }
+
+        AtelierProfileInfoRes atelierProfileInfoRes = AtelierProfileInfoRes.builder()
+                .atelierIdx(atelierIdx)
+                .atelierProfileImage(atelier.getProfileImage())
+                .atelierName(atelier.getName())
+                .atelierAverageScore(atelier.getAverageScore())
+                .havingProductsReviewCount(atelier.getHavingProductsReviewCount())
+                .havingProductsLikeCount(atelier.getHavingProductsLikeCount())
+                .havingFollowerCount(atelier.getHavingFollowerCount())
+                .oneLineDescription(atelier.getOneLineDescription())
+                .memberIsFollow(memberIsFollow)   //memberIdx 가 null 이면 무조건 false
+                .build();
+
+        return atelierProfileInfoRes;
     }
 }

--- a/backend/src/main/java/com/synergy/backend/domain/follow/controller/FollowController.java
+++ b/backend/src/main/java/com/synergy/backend/domain/follow/controller/FollowController.java
@@ -1,0 +1,31 @@
+package com.synergy.backend.domain.follow.controller;
+
+import com.synergy.backend.domain.follow.service.FollowService;
+import com.synergy.backend.global.common.BaseResponse;
+import com.synergy.backend.global.exception.BaseException;
+import com.synergy.backend.global.security.CustomUserDetails;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/follow")
+public class FollowController {
+    private final FollowService followService;
+
+    @PostMapping("click")
+    public BaseResponse<Boolean> clickFollowButton(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                   @RequestBody Map<String, Long> atelierIdx) throws BaseException {
+        Long memberIdx = customUserDetails.getIdx();
+        Long getAtelierIdx = atelierIdx.get("atelierIdx");
+
+        boolean isFollow = followService.clickFollowButton(memberIdx, getAtelierIdx);
+        return new BaseResponse<>(isFollow);
+    }
+}
+

--- a/backend/src/main/java/com/synergy/backend/domain/follow/model/entity/Follow.java
+++ b/backend/src/main/java/com/synergy/backend/domain/follow/model/entity/Follow.java
@@ -1,11 +1,17 @@
-package com.synergy.backend.domain.member.model.entity;
+package com.synergy.backend.domain.follow.model.entity;
 
 import com.synergy.backend.domain.atelier.model.entity.Atelier;
+import com.synergy.backend.domain.member.model.entity.Member;
 import com.synergy.backend.global.common.model.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "follow")
+@Getter
+@NoArgsConstructor
 public class Follow extends BaseEntity {
 
     @Id
@@ -19,4 +25,11 @@ public class Follow extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "atelier_idx")
     private Atelier atelier;
+
+    @Builder
+    public Follow(Long idx, Member member, Atelier atelier) {
+        this.idx = idx;
+        this.member = member;
+        this.atelier = atelier;
+    }
 }

--- a/backend/src/main/java/com/synergy/backend/domain/follow/repository/FollowRepository.java
+++ b/backend/src/main/java/com/synergy/backend/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,13 @@
+package com.synergy.backend.domain.follow.repository;
+
+import com.synergy.backend.domain.atelier.model.entity.Atelier;
+import com.synergy.backend.domain.follow.model.entity.Follow;
+import com.synergy.backend.domain.member.model.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<Follow,Long> {
+    boolean existsByMemberAndAtelier(Member member, Atelier atelier);
+
+    Optional<Follow> findByMemberAndAtelier(Member member, Atelier atelier);
+}

--- a/backend/src/main/java/com/synergy/backend/domain/follow/service/FollowService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/follow/service/FollowService.java
@@ -1,0 +1,69 @@
+package com.synergy.backend.domain.follow.service;
+
+import com.synergy.backend.domain.atelier.model.entity.Atelier;
+import com.synergy.backend.domain.atelier.repository.AtelierRepository;
+import com.synergy.backend.domain.follow.model.entity.Follow;
+import com.synergy.backend.domain.follow.repository.FollowRepository;
+import com.synergy.backend.domain.member.model.entity.Member;
+import com.synergy.backend.domain.member.repository.MemberRepository;
+import com.synergy.backend.global.common.BaseResponseStatus;
+import com.synergy.backend.global.exception.BaseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+    private final FollowRepository followRepository;
+    private final MemberRepository memberRepository;
+    private final AtelierRepository atelierRepository;
+
+    public boolean clickFollowButton(Long memberIdx, Long atelierIdx) throws BaseException {
+        Member member = memberRepository.findById(memberIdx).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.NOT_FOUND_USER));
+        Atelier atelier = atelierRepository.findById(atelierIdx).orElseThrow(
+                () -> new BaseException(BaseResponseStatus.NOT_FOUND_ATELIER));
+
+        boolean isFollow = isFollow(member,atelier);
+
+        // 기존 팔로우 되어있으면 해제
+        if(isFollow){
+            unFollow(member,atelier);
+            return false;
+        }
+        // 팔로우 되어있지 않았으면 팔로우
+        else{
+            follow(member,atelier);
+            return true;
+        }
+    }
+
+    public boolean isFollow(Member member, Atelier atelier){
+        return followRepository.existsByMemberAndAtelier(member, atelier);
+    }
+
+    // 팔로우
+    // 1) 팔로우 DB에 저장
+    // 2) 공방 정보에서 팔로우 수 증가
+    private void follow(Member member, Atelier atelier){
+        Follow follow = Follow.builder()
+                .member(member)
+                .atelier(atelier)
+                .build();
+        followRepository.save(follow);
+
+        atelier.increaseFollowCount();
+        atelierRepository.save(atelier);
+    }
+
+    // 언팔로우
+    // 1) 팔로우 DB에서 삭제
+    // 2) 공방 정보에서 팔로우 수 감소
+    private void unFollow(Member member, Atelier atelier){
+        Long followIdx = followRepository.findByMemberAndAtelier(member,atelier).get().getIdx();
+        followRepository.deleteById(followIdx);
+
+        atelier.decreaseFollowCount();
+        atelierRepository.save(atelier);
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/global/DataInit.java
+++ b/backend/src/main/java/com/synergy/backend/global/DataInit.java
@@ -109,23 +109,23 @@ public class DataInit {
 
         //======================공방 저장===========================
         atelierRepository.save(Atelier.builder()
-                .name("달콤한공방").oneLineDescription("달콤한 디저트를 만드는 공방").address("서울특별시 강남구").addressDetail("테헤란로 123번지").follower(1200).title("달콤한 세상, 디저트").content("마카롱, 쿠키, 케이크 등 다양한 디저트를 제공하는 달콤한공방입니다.").profileImage("https://springprac2024-s3.s3.ap-northeast-2.amazonaws.com/%E1%84%82%E1%85%A9%E1%84%82%E1%85%A9.png")
+                .name("달콤한공방").oneLineDescription("달콤한 디저트를 만드는 공방").address("서울특별시 강남구").addressDetail("테헤란로 123번지").havingFollowerCount(1200).title("달콤한 세상, 디저트").content("마카롱, 쿠키, 케이크 등 다양한 디저트를 제공하는 달콤한공방입니다.").profileImage("https://springprac2024-s3.s3.ap-northeast-2.amazonaws.com/%E1%84%82%E1%85%A9%E1%84%82%E1%85%A9.png")
                 .build());
 
         atelierRepository.save(Atelier.builder()
-                .name("핸드메이드 향기").oneLineDescription("천연 비누와 향초 공방").address("부산광역시 해운대구").addressDetail("해운대로 456번지").follower(850).title("천연의 향기, 핸드메이드 비누").content("자연에서 얻은 재료로 만드는 핸드메이드 비누와 향초를 소개합니다.").profileImage("https://springprac2024-s3.s3.ap-northeast-2.amazonaws.com/%E1%84%82%E1%85%A9%E1%84%82%E1%85%A9.png") // 임의의 URL
+                .name("핸드메이드 향기").oneLineDescription("천연 비누와 향초 공방").address("부산광역시 해운대구").addressDetail("해운대로 456번지").havingFollowerCount(850).title("천연의 향기, 핸드메이드 비누").content("자연에서 얻은 재료로 만드는 핸드메이드 비누와 향초를 소개합니다.").profileImage("https://springprac2024-s3.s3.ap-northeast-2.amazonaws.com/%E1%84%82%E1%85%A9%E1%84%82%E1%85%A9.png") // 임의의 URL
                 .build());
 
         atelierRepository.save(Atelier.builder()
-                .name("예술가의 집").oneLineDescription("공예와 예술작품을 만날 수 있는 공방").address("대구광역시 중구").addressDetail("중앙로 789번지").follower(530).title("예술을 집에서 즐기세요").content("다양한 공예 작품과 그림을 직접 보고 체험할 수 있는 공방입니다.").profileImage("https://springprac2024-s3.s3.ap-northeast-2.amazonaws.com/%E1%84%82%E1%85%A9%E1%84%82%E1%85%A9.png") // 임의의 URL
+                .name("예술가의 집").oneLineDescription("공예와 예술작품을 만날 수 있는 공방").address("대구광역시 중구").addressDetail("중앙로 789번지").havingFollowerCount(530).title("예술을 집에서 즐기세요").content("다양한 공예 작품과 그림을 직접 보고 체험할 수 있는 공방입니다.").profileImage("https://springprac2024-s3.s3.ap-northeast-2.amazonaws.com/%E1%84%82%E1%85%A9%E1%84%82%E1%85%A9.png") // 임의의 URL
                 .build());
 
         atelierRepository.save(Atelier.builder()
-                .name("목공의 세계").oneLineDescription("나무로 만드는 공방").address("전라남도 순천시").addressDetail("순천로 101번지").follower(950).title("나무의 따뜻함을 전하는 공방").content("원목을 이용해 다양한 가구와 소품을 제작하는 공방입니다.").profileImage("https://springprac2024-s3.s3.ap-northeast-2.amazonaws.com/%E1%84%82%E1%85%A9%E1%84%82%E1%85%A9.png") // 임의의 URL
+                .name("목공의 세계").oneLineDescription("나무로 만드는 공방").address("전라남도 순천시").addressDetail("순천로 101번지").havingFollowerCount(950).title("나무의 따뜻함을 전하는 공방").content("원목을 이용해 다양한 가구와 소품을 제작하는 공방입니다.").profileImage("https://springprac2024-s3.s3.ap-northeast-2.amazonaws.com/%E1%84%82%E1%85%A9%E1%84%82%E1%85%A9.png") // 임의의 URL
                 .build());
 
         atelierRepository.save(Atelier.builder()
-                .name("작은 정원").oneLineDescription("플랜테리어와 가드닝 공방").address("경기도 용인시").addressDetail("수지구 202번지").follower(1500).title("식물로 꾸미는 작은 공간").content("플랜테리어 소품과 가드닝 도구를 판매하며, 직접 심고 가꿀 수 있는 체험을 제공합니다.").profileImage("https://springprac2024-s3.s3.ap-northeast-2.amazonaws.com/%E1%84%82%E1%85%A9%E1%84%82%E1%85%A9.png") // 임의의 URL
+                .name("작은 정원").oneLineDescription("플랜테리어와 가드닝 공방").address("경기도 용인시").addressDetail("수지구 202번지").havingFollowerCount(1500).title("식물로 꾸미는 작은 공간").content("플랜테리어 소품과 가드닝 도구를 판매하며, 직접 심고 가꿀 수 있는 체험을 제공합니다.").profileImage("https://springprac2024-s3.s3.ap-northeast-2.amazonaws.com/%E1%84%82%E1%85%A9%E1%84%82%E1%85%A9.png") // 임의의 URL
                 .build());
 
         //======================상품 저장===========================


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->
#24 #25 #26 #31 #32

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->

- 작가 조회 기능 개발
- 기능 개발 중, 팔로우 부분 기능구현이 안된 것을 파악하여 동시 작업

<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->

**다음은 작가 정보 조회시 필요한 데이터 요구사항 정의입니다.**
```
public class AtelierProfileInfoRes {

    // 공방 idx
    private Long atelierIdx;

    // 공방 프로필 이미지
    private String atelierProfileImage;

    // 공방 이름
    private String atelierName;

    // 공방 평점
    private double atelierAverageScore;

    //공방 상품 리뷰 개수
    private int havingProductsReviewCount;

    // 공방이 파는 모든상품 찜 수
    private int havingProductsLikeCount;

    // 공방 팔로워 수
    private int havingFollowerCount;

    // 공방 한줄 소개글
    private String oneLineDescription;

    // 회원-공방 팔로우 여부
    private boolean memberIsFollow;

}
```

**프론트가 실질적으로 받는 데이터 목록입니다.**
```
{
    "isSuccess": true,
    "code": 1000,
    "message": "요청에 성공하였습니다.",
    "result": {
        "atelierIdx": 1,
        "atelierProfileImage": "profile_a.jpg",
        "atelierName": "Atelier A",
        "atelierAverageScore": 4.2,
        "havingProductsReviewCount": 0,
        "havingProductsLikeCount": 0,
        "havingFollowerCount": 251,
        "oneLineDescription": "A creative space",
        "memberIsFollow": true
    }
}
```


<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->

팔로우 변동시 성능적인 이슈가 발생합니다. ( fetch Join 적용 X )

- 성능이슈 : 팔로우 버튼을 클릭
1. 멤버 조회 ( SELECT )
2. 공방 조회 ( SELECT )
3. 팔로우 여부 조회 ( SELECT )
4. 팔로우 데이터 DB 저장 ( INSERT )
5. 공방에서 팔로우 카운트 수 증가 ( UPDATE )

<br><br>

- 성능이슈 : 언팔로우 버튼을 클릭
1. 멤버 조회 ( SELECT )
2. 공방 조회 ( SELECT )
3. 팔로우 여부 조회 ( SELECT )
4. 팔로우 데이터 DB 삭제 ( DELETE )
5. 공방에서 팔로우 카운트 수 감소 ( UPDATE )

추후 개선 완료 하겠습니다.

<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
