### PR TITLE
[Refactor] 팔로우/언팔로우 응답 객체 변경 

### DIFF
--- a/backend/src/main/java/com/synergy/backend/domain/follow/controller/FollowController.java
+++ b/backend/src/main/java/com/synergy/backend/domain/follow/controller/FollowController.java
@@ -1,5 +1,6 @@
 package com.synergy.backend.domain.follow.controller;
 
+import com.synergy.backend.domain.follow.model.response.FollowInfoResponse;
 import com.synergy.backend.domain.follow.service.FollowService;
 import com.synergy.backend.global.common.BaseResponse;
 import com.synergy.backend.global.exception.BaseException;
@@ -19,13 +20,13 @@ public class FollowController {
     private final FollowService followService;
 
     @PostMapping("click")
-    public BaseResponse<Boolean> clickFollowButton(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+    public BaseResponse<FollowInfoResponse> clickFollowButton(@AuthenticationPrincipal CustomUserDetails customUserDetails,
                                                    @RequestBody Map<String, Long> atelierIdx) throws BaseException {
         Long memberIdx = customUserDetails.getIdx();
         Long getAtelierIdx = atelierIdx.get("atelierIdx");
 
-        boolean isFollow = followService.clickFollowButton(memberIdx, getAtelierIdx);
-        return new BaseResponse<>(isFollow);
+        FollowInfoResponse result = followService.clickFollowButton(memberIdx, getAtelierIdx);
+        return new BaseResponse<>(result);
     }
 }
 

--- a/backend/src/main/java/com/synergy/backend/domain/follow/model/response/FollowInfoResponse.java
+++ b/backend/src/main/java/com/synergy/backend/domain/follow/model/response/FollowInfoResponse.java
@@ -1,0 +1,11 @@
+package com.synergy.backend.domain.follow.model.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FollowInfoResponse {
+    private boolean memberIsFollow;
+    private int havingFollowerCount;
+}

--- a/backend/src/main/java/com/synergy/backend/domain/follow/service/FollowService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/follow/service/FollowService.java
@@ -3,6 +3,7 @@ package com.synergy.backend.domain.follow.service;
 import com.synergy.backend.domain.atelier.model.entity.Atelier;
 import com.synergy.backend.domain.atelier.repository.AtelierRepository;
 import com.synergy.backend.domain.follow.model.entity.Follow;
+import com.synergy.backend.domain.follow.model.response.FollowInfoResponse;
 import com.synergy.backend.domain.follow.repository.FollowRepository;
 import com.synergy.backend.domain.member.model.entity.Member;
 import com.synergy.backend.domain.member.repository.MemberRepository;
@@ -18,7 +19,7 @@ public class FollowService {
     private final MemberRepository memberRepository;
     private final AtelierRepository atelierRepository;
 
-    public boolean clickFollowButton(Long memberIdx, Long atelierIdx) throws BaseException {
+    public FollowInfoResponse clickFollowButton(Long memberIdx, Long atelierIdx) throws BaseException {
         Member member = memberRepository.findById(memberIdx).orElseThrow(
                 () -> new BaseException(BaseResponseStatus.NOT_FOUND_USER));
         Atelier atelier = atelierRepository.findById(atelierIdx).orElseThrow(
@@ -26,15 +27,24 @@ public class FollowService {
 
         boolean isFollow = isFollow(member,atelier);
 
+        FollowInfoResponse followInfoResponse;
         // 기존 팔로우 되어있으면 해제
         if(isFollow){
             unFollow(member,atelier);
-            return false;
+            followInfoResponse = FollowInfoResponse.builder()
+                    .memberIsFollow(false)
+                    .havingFollowerCount(atelier.getHavingFollowerCount())
+                    .build();
+            return followInfoResponse;
         }
         // 팔로우 되어있지 않았으면 팔로우
         else{
             follow(member,atelier);
-            return true;
+            followInfoResponse = FollowInfoResponse.builder()
+                    .memberIsFollow(true)
+                    .havingFollowerCount(atelier.getHavingFollowerCount())
+                    .build();
+            return followInfoResponse;
         }
     }
 


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->
#24 

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->

- 팔로우/언팔로우시 응답 객체 변경

<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->

![image](https://github.com/user-attachments/assets/935f4fe7-2523-44af-ae53-2f8827c218a7)

기존, 팔로우/언팔로우의 요청의 대한 응답값은 단순, 본인 현상태 추적을 위해서 boolean isFollow 와 같이 단일값만 배출하였으나, 
팔로우/언팔에 따라 공방의 팔로워 수 증감 실시간성을 위해 응답값을 수정하였습니다. (파랑 네모측)

![image](https://github.com/user-attachments/assets/2ed9708b-1fdb-4c88-acc1-e7bc0b5f7bd7)


<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->

<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
