### PR TITLE
[Fix] params에 따른 카테고리 리스트 갱신 문제 해결

### DIFF
--- a/frontend/src/components/common/HeaderCategoriesComponent.vue
+++ b/frontend/src/components/common/HeaderCategoriesComponent.vue
@@ -82,7 +82,8 @@
                 <router-link
                   v-for="bottom in bottoms"
                   :key="bottom.idx"
-                  :to="{ name: 'categoryProductList', params: { categoryIdx:  bottom.idx},}">
+                  :to="{ name: 'categoryProductList', params: { categoryIdx:  bottom.idx},}"
+                  @click="categoryStore.closeCategory()">
                   <span
                     class="w-full px-[12px] py-[8px] flex items-center gray-333--text body1-regular-small cursor-pointer shrink-0 hover:underline"
                     >{{ bottom.categoryName }}</span

--- a/frontend/src/components/common/TopHeaderComponent.vue
+++ b/frontend/src/components/common/TopHeaderComponent.vue
@@ -90,7 +90,7 @@
                 <!-- 회원 정보 관리 -->
                 <div :style="{ display: upHere ? 'block' : 'none' }" data-v-d1f9d3af="">
                   <div class="BaseMenusItem gray-333--text BaseMenusItem--medium" data-v-a833c376="" data-v-d1f9d3af="">
-                    <router-link to="update/member-info" class="flex items-center w-full px-[12px] cursor-pointer" data-v-a833c376="">
+                    <router-link to="/update/member-info" class="flex items-center w-full px-[12px] cursor-pointer" data-v-a833c376="">
                       <span class="body1-regular-medium" data-v-a833c376="">회원 정보 관리</span>
                     </router-link>
                   </div>

--- a/frontend/src/pages/product/CategoryProductListPage.vue
+++ b/frontend/src/pages/product/CategoryProductListPage.vue
@@ -3342,20 +3342,21 @@ export default {
   },
   data() {
     return {
-      categoryIdx: null, // 초기값 설정
+      // categoryIdx: null, // 초기값 설정
       page:1,
       loading: false //로딩 관리
     };
   },
   created() {
+    this.categoryStore.currentCategoryIdx = this.$route.params.categoryIdx;
+    this.productStore.productList = [];
+    this.getProductListByCateory(this.categoryStore.currentCategoryIdx, 0, 12);
   },
   watch: {
     '$route.params.categoryIdx'(newIdx) {
-        this.categoryIdx = newIdx;
-        console.log("카테고리상세페이지2", this.categoryIdx);
         this.categoryStore.currentCategoryIdx = newIdx;
         this.productStore.productList = [];
-        this.productStore.searchByCategory(newIdx, 0, 12);
+        this.getProductListByCateory(newIdx, 0, 12);
     }
   },
   methods:{

--- a/frontend/src/pages/product/CategoryProductListPage.vue
+++ b/frontend/src/pages/product/CategoryProductListPage.vue
@@ -3323,8 +3323,9 @@
 <script>
 import { mapStores } from "pinia";
 import { useProductStore } from "@/stores/useProductStore";
+import { useCategoryStore } from "@/stores/useCategoryStore";
 
-import { useRoute } from "vue-router";
+// import { useRoute } from "vue-router";
 import SideBarComponent from "@/components/product/SideBarComponent.vue";
 import ProductListComponent from "@/components/product/ProductList4LayoutComponent.vue";
 import ObserverComponent from '@/components/product/ObserverComponent.vue';
@@ -3336,21 +3337,26 @@ export default {
     ObserverComponent
   },
   computed:{
-        ...mapStores(useProductStore)
-    },
+        ...mapStores(useProductStore),
+        ...mapStores(useCategoryStore)
+  },
   data() {
     return {
       categoryIdx: null, // 초기값 설정
-      page:0,
+      page:1,
       loading: false //로딩 관리
     };
   },
   created() {
-    const route = useRoute();
-    this.categoryIdx = route.params.categoryIdx; // 카테고리 ID 가져오기
-    console.log("카테고리상세페이지", this.categoryIdx);
-    this.productStore.productList = []; //상품이 추가되는 원리이기 때문에 이전에 저장됐던 상품 리스트를 초기화
-    // this.getProductListByCateory(this.categoryIdx, 0, 12);
+  },
+  watch: {
+    '$route.params.categoryIdx'(newIdx) {
+        this.categoryIdx = newIdx;
+        console.log("카테고리상세페이지2", this.categoryIdx);
+        this.categoryStore.currentCategoryIdx = newIdx;
+        this.productStore.productList = [];
+        this.productStore.searchByCategory(newIdx, 0, 12);
+    }
   },
   methods:{
       async getProductListByCateory(idx, page, size){
@@ -3365,7 +3371,7 @@ export default {
             }
 
             try {
-                await this.productStore.searchByCategory(this.categoryIdx,this.page, 12);
+                await this.productStore.searchByCategory(this.categoryStore.currentCategoryIdx,this.page, 12);
                 this.page++;
             } catch (error) {
                 console.error("Failed to fetch data:", error);
@@ -3374,17 +3380,6 @@ export default {
             }
         }
   },
-  // watch: {
-  //   "$route.params.categoryIdx": {
-  //     immediate: true,
-  //     handler(newCategoryIdx) {
-  //       this.categoryIdx = newCategoryIdx; // 카테고리 ID 갱신
-  //       console.log("변경된 카테고리 ID:", this.categoryIdx); // 확인용 로그
-  //       // this.getProductListByCateory(this.categoryIdx, 0, 12);
-  //       // console.log(this.productStore.productList);
-  //     },
-  //   },
-  // },
 };
 </script>
 

--- a/frontend/src/stores/useCategoryStore.js
+++ b/frontend/src/stores/useCategoryStore.js
@@ -10,12 +10,16 @@ export const useCategoryStore = defineStore('category', {
         selectedMiddleCategory: null, // 선택된 중분류
         selectedBottomCategory: null, // 선택된 소분류
         parentIdx: 0,
-        isCategoryVisible : false
+        isCategoryVisible : false,
+        currentCategoryIdx : null
     }),
     actions: {
         //category on off
         openCategory() {
             this.isCategoryVisible = !this.isCategoryVisible;
+        },
+        closeCategory(){
+            this.isCategoryVisible = false;
         },
         // 대분류 불러오기
         async loadTopCategories() {


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->
#166 

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->
- 상단 카테고리를 선택했을 때 params 는 전달이 잘 됨
- 하지만 params가 달라짐에도 최초 페이지 접근 이외에는 카테고리 리스트가 갱신되지 않는 문제를 겪음
- params를 전역처리해서 해결

<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->
- 전달되는 param를 categoryStore를 이용해 전역적으로 저장함으로써 갱신 문제를 해결했습니다.
- 추가로 카테고리 리스트가 초기세팅되는 경우는 두가지인데, 처음 컴포넌트가 생성될 때 그리고 params가 변경될 때입니다.
- 이 두가지 상황을 모두 보완하기 위해 create와 watch를 같이 사용했습니다.

<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->
- 아직 사이드바와 연결이 안됐습니다.
<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
