### PR TITLE
[Refactor] 상품 상세 응답 정보에 작가 Idx 추가

### DIFF
--- a/backend/src/main/java/com/synergy/backend/domain/product/model/response/ProductInfoRes.java
+++ b/backend/src/main/java/com/synergy/backend/domain/product/model/response/ProductInfoRes.java
@@ -12,6 +12,8 @@ import lombok.Getter;
 public class ProductInfoRes {
     // 상품 idx
     private Long productIdx;
+    // 작가 idx
+    private Long atelierIdx;
     // 상픔 이름
     private String productName;
     // 상품 썸네일
@@ -54,7 +56,7 @@ public class ProductInfoRes {
 //    private String productType;
 
     @Builder
-    public ProductInfoRes(String productThumbnail, List<ProductImagesRes> productImages, Long productIdx,
+    public ProductInfoRes(String productThumbnail, List<ProductImagesRes> productImages, Long productIdx, Long atelierIdx,
                           String productName, int productPrice, int productOnSalePercent, int productOnSalePrice,
                           int productFinalPrice, Double productAverageScore,
                           List<ProductMajorOptionsRes> productOptions, String productDescription,
@@ -63,6 +65,7 @@ public class ProductInfoRes {
         this.productThumbnail = productThumbnail;
         this.productImages = productImages;
         this.productIdx = productIdx;
+        this.atelierIdx = atelierIdx;
         this.productName = productName;
         this.productPrice = productPrice;
         this.productOnSalePercent = productOnSalePercent;

--- a/backend/src/main/java/com/synergy/backend/domain/product/service/ProductService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/product/service/ProductService.java
@@ -84,7 +84,9 @@ public class ProductService {
         Member member = memberRepository.findById(memberIdx).orElseThrow(() ->
                 new BaseException(BaseResponseStatus.NOT_FOUND_USER));
 
+        // 작가 정보
         Atelier atelier = product.getAtelier();
+        Long atelierIdx = atelier.getIdx();
 
         // 상품 이미지들
         List<ProductImagesRes> productImagesRes = new ArrayList<>();
@@ -137,6 +139,7 @@ public class ProductService {
 
         ProductInfoRes response = ProductInfoRes.builder()
                 .productIdx(product.getIdx())
+                .atelierIdx(atelierIdx)
                 .productName(product.getName())
                 .productThumbnail(product.getThumbnailUrl())
                 .productImages(productImagesRes)


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->

- 기존에 없었던 atelierIdx 추가

<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->

상품 상세페이지에서 공방에 대한 페이지로 넘어갈 때, 기존에 적용했던 productIdx를 넘기는 것 보다, 
atelierIdx 로 넘기는 것이 낫다고 판단하여 수정하였습니다.

<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->

<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
