### PR TITLE
[Feat] 쿠폰 발행 기본 기능, 등급 할인율 조회 api 

### DIFF
--- a/backend/src/main/java/com/synergy/backend/domain/coupon/controller/CouponController.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/controller/CouponController.java
@@ -1,11 +1,14 @@
 package com.synergy.backend.domain.coupon.controller;
 
 import com.synergy.backend.domain.coupon.scheduler.CouponScheduler;
+import com.synergy.backend.domain.coupon.service.CouponService;
+import com.synergy.backend.global.common.BaseResponse;
+import com.synergy.backend.global.common.BaseResponseStatus;
 import com.synergy.backend.global.exception.BaseException;
+import com.synergy.backend.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -13,6 +16,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class CouponController {
 
     private final CouponScheduler couponScheduler;
+    private final CouponService couponService;
+
+    @PostMapping("/{couponIdx}/issue")
+    public BaseResponse<Void> issueCoupon(@PathVariable Long couponIdx,
+                                          @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
+        if(customUserDetails.getIdx() == null){
+            throw new BaseException(BaseResponseStatus.UNAUTHORIZED);
+        }
+        couponService.issueCoupon(customUserDetails.getIdx(), couponIdx);
+        return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+    }
+
 
     //내 쿠폰 조회, 페이징 처리
 

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/model/entity/Coupon.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/model/entity/Coupon.java
@@ -1,16 +1,16 @@
 package com.synergy.backend.domain.coupon.model.entity;
 
 import com.synergy.backend.domain.coupon.model.type.CouponType;
+import com.synergy.backend.domain.coupon.model.type.IssueDate;
 import com.synergy.backend.domain.grade.model.entity.Grade;
 import com.synergy.backend.global.common.model.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @Table(name = "coupon")
 public class Coupon extends BaseEntity {
     @Id
@@ -24,7 +24,30 @@ public class Coupon extends BaseEntity {
     private String code;
     private Integer discountPercent;
 
+    private Integer totalQuantity;
+    private Integer issuedQuantity = 0;
+    @Embedded
+    private IssueDate issueDate;
+
+    private LocalDateTime usageTimes;
+
+
+
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "grade_idx")
+    @JoinColumn(name = "grade_idx", nullable = true)
     private Grade grade;
+
+
+    // 발급 가능,수량 제한 없을 때, 선착순 쿠폰이면 수량이 남아있을 때
+    public boolean isAvailable() {
+        return totalQuantity == null || issuedQuantity < totalQuantity;
+    }
+
+    public void increaseCouponQuantity() {
+        if (this.totalQuantity != null
+                && this.issuedQuantity < this.totalQuantity) {
+            this.issuedQuantity++;
+        }
+    }
+
 }

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/model/entity/MemberCoupon.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/model/entity/MemberCoupon.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import org.springframework.cglib.core.Local;
 
 import java.time.LocalDateTime;
 
@@ -29,4 +30,13 @@ public class MemberCoupon {
     @JoinColumn(name = "member_idx")
     private Member member;
 
+
+    public static MemberCoupon issued(Coupon coupon, Member member) {
+        return MemberCoupon.builder()
+                .coupon(coupon)
+                .expirationDate(coupon.getUsageTimes())
+                .member(member)
+                .publicationDate(LocalDateTime.now())
+                .build();
+    }
 }

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/model/type/IssueDate.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/model/type/IssueDate.java
@@ -1,0 +1,22 @@
+package com.synergy.backend.domain.coupon.model.type;
+
+import com.synergy.backend.global.common.BaseResponseStatus;
+import com.synergy.backend.global.exception.BaseException;
+import jakarta.persistence.Column;
+
+import java.time.LocalDateTime;
+
+//쿠폰 발급 기간
+public class IssueDate {
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+    @Column(name = "finished_at")
+    private LocalDateTime finishedAt;
+
+    public void validate(LocalDateTime currentTime) throws BaseException {
+        if (currentTime.isBefore(startedAt) || currentTime.isAfter(finishedAt)) {
+            throw new BaseException(BaseResponseStatus.COUPON_ISSUANCE_PERIOD_NOT);
+        }
+    }
+}

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/repository/CouponRepository.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/repository/CouponRepository.java
@@ -3,7 +3,9 @@ package com.synergy.backend.domain.coupon.repository;
 
 import com.synergy.backend.domain.coupon.model.entity.Coupon;
 import com.synergy.backend.domain.coupon.model.type.CouponType;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,5 +14,12 @@ import java.util.Optional;
 public interface CouponRepository extends JpaRepository<Coupon, Long> {
 
     @Query("SELECT c FROM Coupon c WHERE c.grade.idx = :gradeId AND c.type = :type")
-    Coupon findCouponsByGradeWithRecur(@Param("gradeId") Long gradeId, @Param("type") CouponType type);
+    Coupon findCouponsByGradeWithRecur(@Param("gradeId") Long gradeId,
+                                       @Param("type") CouponType type);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Coupon c WHERE c.idx = :couponIdx")
+    Optional<Coupon> findByWithPessimisticLock(@Param("couponId") Long couponIdx);
+
+
 }

--- a/backend/src/main/java/com/synergy/backend/domain/coupon/service/CouponService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/coupon/service/CouponService.java
@@ -1,11 +1,45 @@
 package com.synergy.backend.domain.coupon.service;
 
+import com.synergy.backend.domain.coupon.model.entity.Coupon;
+import com.synergy.backend.domain.coupon.model.entity.MemberCoupon;
+import com.synergy.backend.domain.coupon.repository.CouponRepository;
+import com.synergy.backend.domain.coupon.repository.MemberCouponRepository;
+import com.synergy.backend.domain.member.model.entity.Member;
+import com.synergy.backend.domain.member.repository.MemberRepository;
+import com.synergy.backend.global.common.BaseResponseStatus;
+import com.synergy.backend.global.exception.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class CouponService {
 
+    private final CouponRepository couponRepository;
+    private final MemberCouponRepository memberCouponRepository;
+    private final MemberRepository memberRepository;
 
+    public void issueCoupon(Long memberIdx, Long couponIdx) throws BaseException {
+        Coupon coupon = couponRepository.findByWithPessimisticLock(couponIdx)
+                .orElseThrow(() ->
+                        new BaseException(BaseResponseStatus.COUPON_NOT_FOUND));
+
+        Member member = memberRepository.findById(memberIdx)
+                .orElseThrow(() ->
+                        new BaseException(BaseResponseStatus.NOT_FOUND_MEMBER));
+
+        if (!coupon.isAvailable()) {
+            throw new BaseException(BaseResponseStatus.COUPON_SOLD_OUT);
+        }
+        coupon.getIssueDate().validate(LocalDateTime.now());
+
+        coupon.increaseCouponQuantity();
+
+        MemberCoupon issued = MemberCoupon.issued(coupon, member);
+        memberCouponRepository.save(issued);
+
+
+    }
 }

--- a/backend/src/main/java/com/synergy/backend/domain/grade/controller/GradeController.java
+++ b/backend/src/main/java/com/synergy/backend/domain/grade/controller/GradeController.java
@@ -25,11 +25,17 @@ public class GradeController {
 
     //내 등급 조회
     @GetMapping("/me")
-    public BaseResponse<GetMyGradeRes> getMyGrade(@AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
+    public BaseResponse<GetMyGradeRes> getMyGrade(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
         GetMyGradeRes myGrade = gradeService.getMyGrade(customUserDetails.getIdx());
         return new BaseResponse<>(myGrade);
     }
 
+    @GetMapping("/me/percent")
+    public BaseResponse<Integer> getMyGradePercent(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
+        return new BaseResponse<>(gradeService.getMyGradePercent(customUserDetails.getIdx()));
+    }
 
     //모든 등급 조회
     @GetMapping("/info")

--- a/backend/src/main/java/com/synergy/backend/domain/grade/service/GradeService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/grade/service/GradeService.java
@@ -108,13 +108,19 @@ public class GradeService {
             benefitsMessage = "현재 등급은 " + curGradeName + "입니다.";
         }
 
-        return GetMyGradeRes.from(curGradeName, expectedGrade,expectedGradeBenefit, amountToNext, allGrades, benefitsMessage);
+        return GetMyGradeRes.from(curGradeName, expectedGrade, expectedGradeBenefit, amountToNext, allGrades, benefitsMessage);
     }
 
 
     public String formatCurrency(Integer amount) {
         NumberFormat formatter = NumberFormat.getInstance(new Locale("ko", "KR"));
         return formatter.format(amount);
+    }
+
+    public Integer getMyGradePercent(Long memberIdx) throws BaseException {
+        Member member = memberRepository.findById(memberIdx).orElseThrow(() ->
+                new BaseException(BaseResponseStatus.NOT_FOUND_MEMBER));
+        return member.getGrade().getDefaultPercent();
     }
 }
 

--- a/backend/src/main/java/com/synergy/backend/global/InitData/DataInit.java
+++ b/backend/src/main/java/com/synergy/backend/global/InitData/DataInit.java
@@ -50,7 +50,7 @@ public class DataInit {
 
     private final Random random = new Random();
 
-    @PostConstruct
+//    @PostConstruct
     public void dataInsert() {
 
         //====================== 등급 저장 ===========================

--- a/backend/src/main/java/com/synergy/backend/global/common/BaseResponseStatus.java
+++ b/backend/src/main/java/com/synergy/backend/global/common/BaseResponseStatus.java
@@ -12,6 +12,7 @@ public enum BaseResponseStatus {
      * 필터 단계에서 확인되는 에러는 실제 에러코드 형태여야 함.
      */
     FAIL(false, 400, "요청 실패"),
+    UNAUTHORIZED(false, 401, "인증되지 않은 회원입니다."),
     EXPIRED_TOKEN(false, 500, "만료된 토큰 입니다."),
 
 
@@ -22,12 +23,15 @@ public enum BaseResponseStatus {
 
 
     /**
-     * 2000: 유저, 등급, 팔로우
+     * 2000: 유저, 등급, 팔로우, 쿠폰
      */
     NOT_FOUND_MEMBER(false, 2000, "회원을 찾을 수 없습니다."),
     REQUIRED_VALUE_NOT_ENTERED(false, 2001, "필수값이 모두 입력되지 않았습니다."),
     NEED_TO_LOGIN(false, 2002, "로그인이 필요한 서비스입니다."),
     ALREADY_EXIST_MEMBER(false,2003,"이미 존재하는 이메일입니다."),
+    COUPON_NOT_FOUND(false,2004, "쿠폰이 존재하지 않습니다."),
+    COUPON_SOLD_OUT(false,2004, "쿠폰이 모두 소진되었습니다. "),
+    COUPON_ISSUANCE_PERIOD_NOT(false,2004, "쿠폰 발급기간이 아닙니다."),
 
 
     /**


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->
#53 #283

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->

 쿠폰 발행 기능
등급 할인율 조회 api 

<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->

1. 쿠폰 발행 기본 기능입니다. 
동시성 제어를 위한 여러가지 방법 중 DB에서 직접 락을 거는 비관적 락을 사용해서 동시성 제어를 진행했습니다.
비관적 락을 선택한 이유는 다른 락보다 성능은 떨어질지 몰라도 선착순 쿠폰은 정확한 수량이 정확하게 발행되는 것이 중요하기 때문에 비관적 락을 통해 일관성을 지켰습니다.

쿠폰 엔티티와 memberCoupon 엔티티의 속성이 일부 변경되었습니다.
쿠폰 엔티티에 날짜와 수량 정보가 들어갔습니다.
기존 방식은 쿠폰엔 날짜와 수량을 작성하지 않고 memberCoupon에 작성해서 같은 쿠폰이여도 회원별 다른 날짜를 적용하도록 해서 쿠폰 엔티티를 재사용하도록 했었습니다
하지만 쿠폰에 날짜와 수량이 있어야 쿠폰을 발행하는 이벤트에서 좀 더 빠르고 명확하게 수량을 확인할 수 있기 때문에 추가했습니다.

```
    private Integer totalQuantity;
    private Integer issuedQuantity = 0;
    @Embedded
    private IssueDate issueDate;

    private LocalDateTime usageTimes;
```

그래서 이후 쿠폰 배치 시스템도 일부 변경이 들어갈예정입니다. 


2. 등급 할인 조회하는 단일 api는 간단하기 때문에 같이 pr 올렸습니다.




<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->

<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
