### PR TITLE
[Refactor,Style] 카테고리 조회 성능 개선 및 컨벤션 준수

### DIFF
--- a/backend/src/main/java/com/synergy/backend/domain/product/controller/CategoryController.java
+++ b/backend/src/main/java/com/synergy/backend/domain/product/controller/CategoryController.java
@@ -1,16 +1,19 @@
 package com.synergy.backend.domain.product.controller;
 
 import com.synergy.backend.domain.product.model.CategoryDto;
-import com.synergy.backend.domain.product.model.entity.Category;
 import com.synergy.backend.domain.product.service.CategoryService;
 import com.synergy.backend.global.common.BaseResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 @RequestMapping("/categories")
 public class CategoryController {
 
@@ -20,27 +23,21 @@ public class CategoryController {
     // 대분류 카테고리 조회
     @GetMapping("/top")
     public BaseResponse<List<CategoryDto>> getTopCategories() {
-        List<CategoryDto> topCategories = categoryService.getTopCategories().stream()
-                .map(CategoryDto::toDto)
-                .toList();
+        List<CategoryDto> topCategories = categoryService.getTopCategories();
         return new BaseResponse<>(topCategories);
     }
 
     // 중분류 카테고리 조회
     @GetMapping("/middle/{topCategoryId}")
     public BaseResponse<List<CategoryDto>> getMiddleCategories(@PathVariable Long topCategoryId) {
-        List<CategoryDto> middleCategories = categoryService.getMiddleCategories(topCategoryId).stream()
-                .map(CategoryDto::toDto)
-                .toList();
+        List<CategoryDto> middleCategories = categoryService.getMiddleCategories(topCategoryId);
         return new BaseResponse<>(middleCategories);
     }
 
     // 소분류 카테고리 조회 (특정 중분류에 속한 소분류들)
     @GetMapping("/bottom/{middleCategoryId}")
     public BaseResponse<List<CategoryDto>> getBottomCategories(@PathVariable Long middleCategoryId) {
-        List<CategoryDto> bottomCategories = categoryService.getBottomCategories(middleCategoryId).stream()
-                .map(CategoryDto::toDto)  // 엔티티 -> DTO 변환
-                .toList();
+        List<CategoryDto> bottomCategories = categoryService.getBottomCategories(middleCategoryId);
         return new BaseResponse<>(bottomCategories);
     }
 }

--- a/backend/src/main/java/com/synergy/backend/domain/product/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/synergy/backend/domain/product/repository/CategoryRepository.java
@@ -12,7 +12,8 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     List<Category> findByParentCategoryIsNull();
 
     // 특정 부모 카테고리의 하위 카테고리 조회
-    List<Category> findByParentCategoryIdx(Long parentCategoryIdx);
+    @Query("SELECT c FROM Category c LEFT JOIN FETCH c.subCategories sc WHERE c.parentCategory.idx = :parentCategoryIdx ORDER BY c.idx ASC")
+    List<Category> findByParentCategoryIdxWithSubCategories(@Param("parentCategoryIdx") Long parentCategoryIdx);
 
 }
 

--- a/backend/src/main/java/com/synergy/backend/domain/product/service/CategoryService.java
+++ b/backend/src/main/java/com/synergy/backend/domain/product/service/CategoryService.java
@@ -1,7 +1,9 @@
 package com.synergy.backend.domain.product.service;
 
+import com.synergy.backend.domain.product.model.CategoryDto;
 import com.synergy.backend.domain.product.model.entity.Category;
 import com.synergy.backend.domain.product.repository.CategoryRepository;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,23 +15,44 @@ public class CategoryService {
 
     private final CategoryRepository categoryRepository;
 
+    //TODO : 중복 코드 제거
+
     // 부모 카테고리 조회
-    public List<Category> getTopCategories() {
-        System.out.println(categoryRepository.findByParentCategoryIsNull());
-        return categoryRepository.findByParentCategoryIsNull();
+    public List<CategoryDto> getTopCategories() {
+        List<Category> categories = categoryRepository.findByParentCategoryIsNull();
+
+        List<CategoryDto> categoryDtos = new ArrayList<>();
+        for(Category category : categories){
+            CategoryDto dto = CategoryDto.toDto(category);
+            categoryDtos.add(dto);
+        }
+
+        return categoryDtos;
     }
 
     // 특정 상위카테고리의 하위 카테고리 조회
-    public List<Category> getMiddleCategories(Long topCategoryIdx) {
-        return categoryRepository.findByParentCategoryIdx(topCategoryIdx);
-//                .orElseThrow(() -> new IllegalArgumentException("Top category not found"));
-
+    public List<CategoryDto> getMiddleCategories(Long topCategoryIdx) {
+        List<Category> categories = categoryRepository.findByParentCategoryIdxWithSubCategories(topCategoryIdx);
+        
+        List<CategoryDto> categoryDtos = new ArrayList<>();
+        for(Category category : categories){
+            CategoryDto dto = CategoryDto.toDto(category);
+            categoryDtos.add(dto);
+        }
+        
+        return categoryDtos;
     }
 
     // 특정 중위카테고리의 하위 카테고리 조회
-    public List<Category> getBottomCategories(Long middleCategoryIdx) {
-        categoryRepository.findById(middleCategoryIdx)
-                .orElseThrow(() -> new IllegalArgumentException("Middle category not found"));
-        return categoryRepository.findByParentCategoryIdx(middleCategoryIdx);
+    public List<CategoryDto> getBottomCategories(Long middleCategoryIdx) {
+        List<Category> categories = categoryRepository.findByParentCategoryIdxWithSubCategories(middleCategoryIdx);
+
+        List<CategoryDto> categoryDtos = new ArrayList<>();
+        for(Category category : categories){
+            CategoryDto dto = CategoryDto.toDto(category);
+            categoryDtos.add(dto);
+        }
+
+        return categoryDtos;
     }
 }


### PR DESCRIPTION
## 📚이슈 번호
<!-- #이슈번호를 기재해주세요 -->

## 📃요약
<!-- 작업에 대한 내용을 간단하게 적어주세요.-->

- LAZY + fetch join 전략을 이용해 조회 성능 개선
- 시너지팀에 맞는 코드 컨벤션 준수

<br><br>

## 💪작업 상세 내용
<!-- 추후, 포트폴리오로도 쓸 수 있는 작업 내용입니다. 
"가능한" 최대한 자세하고 설명문처럼 작성해주세요. 사진 첨부도 가능합니다.-->
코드 컨벤션을 준수하였으며, 
LAZY + Fetch Join 전략을 통해 조회 성능을 높였습니다.


<br><br>

## 🙇‍♀ 이슈 / 의논 거리
<!-- 발생한 이슈나 의논거리가 있다면 해당란에 기재해주세요. (생략가능 합니다)-->
 카테고리 조회시, 왜 하위카테고리가 뒤바뀌는지 모르겠습니다. 백엔드에서 순차적으로 주지 않아서 발생한 것인가 하여, 
오름차순 으로 던져줬으나 변동사항은 없었고, 정황상 프론트측에서 api 요청 할 때 idx 를 순서없이 던져주는 것 같은 느낌도 들고 있습니다! 

한번 더 클릭하면 다시 재정렬되어 당장 큰 문제는 없을것으로 보입니다.

![image](https://github.com/user-attachments/assets/6147e43c-cf75-46e5-a3a9-5e7b7f6c0c00)


<br><br>

## 💭참고 자료
<!-- 관련된 참고할만한 자료가 있다면, 해당란에 기재해주세요.
[주소에 대한 설명](http://www.google.co.kr) -->

<br><br>
